### PR TITLE
Bump hyper version to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ documentation = "http://lipanski.github.io/mockito"
 description = "HTTP mocking for Rust"
 
 [dependencies]
-hyper = "^0.8.0"
+hyper = "^0.10.0"
 rustc-serialize = "^0.3.16"
 rand = "^0.3.14"


### PR DESCRIPTION
According to the changelog on Hyper non of the breaking changes should
cause issues with this crate.

https://github.com/hyperium/hyper/blob/v0.10.4/CHANGELOG.md#breaking-changes-1