### PR TITLE
Change usage of rustc_serialize to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ description = "HTTP mocking for Rust"
 
 [dependencies]
 hyper = "^0.10.0"
-rustc-serialize = "^0.3.16"
 rand = "^0.3.14"
+serde = "0.9"
+serde_derive = "0.9"
+serde_json = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,8 @@
 //!
 
 extern crate hyper;
-extern crate rustc_serialize;
+#[macro_use] extern crate serde_derive;
+extern crate serde_json;
 extern crate rand;
 
 mod server;
@@ -146,8 +147,6 @@ use std::io::Read;
 use hyper::client::Client;
 use hyper::server::Request;
 use hyper::header::{Headers, ContentType, Connection};
-use rustc_serialize::json;
-use rustc_serialize::{Encodable};
 use rand::{thread_rng, Rng};
 
 ///
@@ -343,7 +342,7 @@ impl Mock {
             headers.set_raw("x-mock-".to_string() + field, vec!(value.as_bytes().to_vec()));
         }
 
-        let body = json::encode(&self.response).unwrap();
+        let body = serde_json::to_string(&self.response).unwrap();
         Client::new()
             .post(&[SERVER_URL, "/mocks"].join(""))
             .headers(headers)
@@ -447,7 +446,7 @@ impl Mock {
 
 const DEFAULT_RESPONSE_STATUS: usize = 200;
 
-#[derive(RustcDecodable, RustcEncodable, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct MockResponse {
     status: usize,
     headers: HashMap<String, String>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use hyper::server::{Handler, Server, Request, Response};
 use hyper::header::ContentLength;
 use hyper::method::{Method};
 use hyper::status::StatusCode;
-use rustc_serialize::json;
+use serde_json;
 use {Mock, MockResponse, SERVER_ADDRESS};
 
 #[derive(Debug)]
@@ -115,7 +115,7 @@ impl RequestHandler {
         let mut body = String::new();
         request.take(content_length.0).read_to_string(&mut body).unwrap();
 
-        let response: MockResponse = try!(json::decode(&body).map_err(|_| CreateMockError::InvalidMockResponse));
+        let response: MockResponse = try!(serde_json::from_str(&body).map_err(|_| CreateMockError::InvalidMockResponse));
         mock.response = response;
 
         Ok(mock)


### PR DESCRIPTION
I'm interested in adding support for users to match mocks based on the request body. This PR makes that a little bit easier. Are you interested in that feature?