### PR TITLE
Don't expose server to the network

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,12 +192,12 @@ use rand::{thread_rng, Rng};
 /// Points to the address the mock server is running at.
 /// Can be used with `std::net::TcpStream`.
 ///
-pub const SERVER_ADDRESS: &'static str = "0.0.0.0:1234";
+pub const SERVER_ADDRESS: &'static str = "127.0.0.1:1234";
 
 ///
 /// Points to the URL the mock server is running at.
 ///
-pub const SERVER_URL: &'static str = "http://0.0.0.0:1234";
+pub const SERVER_URL: &'static str = "http://127.0.0.1:1234";
 
 ///
 /// Initializes a mock for the provided `method` and `path`.


### PR DESCRIPTION
Currently, Mockito binds its server to 0.0.0.0, which exposed the server to every host on the network. This _probably_ isn't the correct behavior. It also generated several annoying firewall popups per test 
run on my machine (using the default macOS firewall settings, AFAIK).

<img width="506" alt="screen shot 2017-05-20 at 13 02 36" src="https://cloud.githubusercontent.com/assets/2768870/26275633/701460f6-3d5d-11e7-8a52-f8c5e6d3ba48.png">

This PR changes the server to run on 127.0.0.1, so it's not accessible to other machines.