### PR TITLE
Preserve response header order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ impl Mock {
     /// ```
     ///
     pub fn with_header(&mut self, field: &str, value: &str) -> &mut Self {
-        self.response.headers.insert(field.to_owned(), value.to_owned());
+        self.response.headers.push((field.to_owned(), value.to_owned()));
 
         self
     }
@@ -521,7 +521,7 @@ const DEFAULT_RESPONSE_STATUS: usize = 200;
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct MockResponse {
     status: usize,
-    headers: HashMap<String, String>,
+    headers: Vec<(String, String)>,
     body: String,
 }
 
@@ -529,7 +529,7 @@ impl MockResponse {
     pub fn new() -> Self {
         MockResponse {
             status: DEFAULT_RESPONSE_STATUS,
-            headers: HashMap::new(),
+            headers: Vec::new(),
             body: String::new(),
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -67,7 +67,7 @@ impl RequestHandler {
                 mem::replace(response.status_mut(), StatusCode::Unregistered(mock.response.status as u16));
 
                 // Set the response headers
-                for (field, value) in &mock.response.headers {
+                for &(ref field, ref value) in &mock.response.headers {
                     response.headers_mut().set_raw(field.to_owned(), vec!(value.as_bytes().to_vec()));
                 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -260,6 +260,30 @@ fn test_mock_with_multiple_headers() {
 }
 
 #[test]
+fn test_mock_preserves_header_order() {
+    reset();
+
+    let mut expected_headers = Vec::new();
+    let mut mock = mock("GET", "/");
+
+    // Add a large number of headers so getting the same order accidentally is unlikely.
+    for i in 0..100 {
+        let field = format!("x-custom-header-{}", i);
+        let value = "test";
+        mock.with_header(&field, value);
+        expected_headers.push(format!("{}: {}", field, value));
+    }
+
+    mock.create();
+
+    let (_, headers, _) = request("GET /", "");
+    let custom_headers: Vec<_> = headers.into_iter()
+        .filter(|header| header.starts_with("x-custom-header"))
+        .collect();
+    assert_eq!(custom_headers, expected_headers);
+}
+
+#[test]
 fn test_reset_clears_mocks() {
     reset();
 


### PR DESCRIPTION
I came across some intermittent test failures when working on some code that serializes HTTP responses. This seemed like it should be deterministic, so this was very surprising.

It turned out that the problem came from Mockito using a `HashMap` to store response headers. Switching this to an array, and explcitly specifying a static `Date` header, should be enough to make Mockito responses entirely deterministic, which is especially desirable in a library focused on testing.