### PR TITLE
don't panic about Utf8Error on large utf8 body

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -13,7 +13,7 @@ pub struct Request {
     pub method: String,
     pub path: String,
     pub headers: HashMap<String, String>,
-    pub body: String,
+    pub body: Vec<u8>,
     error: Option<String>,
     is_parsed: bool,
     last_header_field: Option<String>,
@@ -49,7 +49,7 @@ impl Default for Request {
             method: String::new(),
             path: String::new(),
             headers: HashMap::new(),
-            body: String::new(),
+            body: Vec::new(),
             error: None,
             is_parsed: false,
             last_header_field: None,
@@ -126,7 +126,7 @@ impl ParserHandler for Request {
     }
 
     fn on_body(&mut self, parser: &mut Parser, value: &[u8]) -> bool {
-        self.body.push_str(str::from_utf8(value).unwrap());
+        self.body.extend(value);
 
         !parser.has_error()
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -45,7 +45,7 @@ fn handle_request(mut mocks: &mut Vec<Mock>, request: Request, stream: TcpStream
 }
 
 fn handle_create_mock(mut mocks: &mut Vec<Mock>, request: Request, mut stream: TcpStream) {
-    match serde_json::from_str(&request.body) {
+    match serde_json::from_slice(&request.body) {
         Ok(mock) => {
             mocks.push(mock);
             stream.write("HTTP/1.1 200 OK\r\n\r\n".as_bytes()).unwrap();


### PR DESCRIPTION
Hello!
It's me again )

Sorry about noise from me, but I'm have `Utf8Error` issue when mock response with utf8 files around 200-500K. 

Bug was on code:
```
self.body.push_str(str::from_utf8(value).unwrap());
```
Where `value` is 1024 length buffer of `u8` wich can contain not valid utf8 string (truncated if source utf8 string large then 1024 bytes) and on `unwrap` mocking server panics with  `Utf8Error`

Solution is:
 - gather full request body to `Vec<u8>` from read buffer
 - deserilize raw request body from slice directly and don't panic on some error