### PR TITLE
bind server address once

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -48,6 +48,7 @@ impl<'a> PartialEq<Request> for &'a mut Mock {
 }
 
 pub struct State {
+    pub is_listening: bool,
     pub mocks: Vec<Mock>,
     pub unmatched_requests: Vec<Request>,
 }
@@ -55,6 +56,7 @@ pub struct State {
 impl Default for State {
     fn default() -> Self {
         State {
+            is_listening: is_listening(),
             mocks: Vec::new(),
             unmatched_requests: Vec::new(),
         }
@@ -72,6 +74,14 @@ pub fn try_start() {
 }
 
 fn start() {
+
+    let state_mutex = STATE.clone();
+    let mut state = state_mutex.lock().unwrap();
+
+    if state.is_listening {
+        return
+    }
+
     thread::spawn(move || {
         let listener = TcpListener::bind(SERVER_ADDRESS).unwrap();
         for stream in listener.incoming() {
@@ -91,6 +101,7 @@ fn start() {
     });
 
     while !is_listening() {}
+    state.is_listening = true;
 }
 
 fn is_listening() -> bool {


### PR DESCRIPTION
Hello!
It's me again.

In my test all mocks are unique and I want run tests without `--test-threads=1`

```
$ cargo test --all
...
running 3 tests
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 98, message: "Address already in use" } }', /checkout/src/libcore/result.rs:860:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 98, message: "Address already in use" } }', /checkout/src/libcore/result.rs:860:4
test test_1... ok
test test_2 ... ok
test test_3 ... ok
```

With this PR  tests runs without noise about paniced threads.

```
$ cargo test --all
...
running 3 tests                    
test test_1 ... ok                             
test test_2 ... ok       
test test_3 ... ok       

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out 
```

Note this PR does't solve problem testings when mocks are duplicated without `--test-threads=1`

Sorry about my poor English.