### PR TITLE
remove useless mut keywords in order to prevent compilation warnings

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -67,7 +67,7 @@ impl Default for Request {
 }
 
 impl<'a> From<&'a mut TcpStream> for Request {
-    fn from(mut stream: &mut TcpStream) -> Self {
+    fn from(stream: &mut TcpStream) -> Self {
         let mut request = Request::default();
         let mut parser = Parser::request();
         let mut first_read = true;

--- a/src/server.rs
+++ b/src/server.rs
@@ -117,7 +117,7 @@ fn handle_match_mock(request: Request, stream: TcpStream) {
     let mut state = state_mutex.lock().unwrap();
 
     match state.mocks.iter_mut().rev().find(|mock| mock == &request) {
-        Some(mut mock) => {
+        Some(mock) => {
             found = true;
 
             mock.hits = mock.hits + 1;


### PR DESCRIPTION
Prevents the following warnings at compile time:

```
warning: variable does not need to be mutable                                                                                                                                                        
   --> src/server.rs:120:14                                                                                                                                                                          
    |                                                                                                                                                                                                
120 |         Some(mut mock) => {                                                                                                                                                                    
    |              ----^^^^                                                                                                                                                                          
    |              |                                                                                                                                                                                 
    |              help: remove this `mut`                                                                                                                                                           
    |                                                                                                                                                                                                
    = note: #[warn(unused_mut)] on by default                                                                                                                                                        
                                                                                                                                                                                                     
warning: variable does not need to be mutable                                                                                                                                                        
  --> src/request.rs:70:13                                                                                                                                                                           
   |                                                                                                                                                                                                 
70 |     fn from(mut stream: &mut TcpStream) -> Self {                                                                                                                                               
   |             ----^^^^^^                                                                                                                                                                          
   |             |                                                                                                                                                                                   
   |             help: remove this `mut`                                                                                                                                                             
                                                                                                                                                                                                     
warning: variable does not need to be mutable                                                                                                                                                        
   --> src/server.rs:120:14                                                                                                                                                                          
    |                                                                                                                                                                                                
120 |         Some(mut mock) => {                                                                                                                                                                    
    |              ----^^^^                                                                                                                                                                          
    |              |                                                                                                                                                                                 
    |              help: remove this `mut`                                                                                                                                                           
    |                                                                                                                                                                                                
    = note: #[warn(unused_mut)] on by default                                                                                                                                                        
                                                                                                                                                                                                     
warning: variable does not need to be mutable                                                                                                                                                        
  --> src/request.rs:70:13                                                                                                                                                                           
   |                                                                                                                                                                                                 
70 |     fn from(mut stream: &mut TcpStream) -> Self {                                                                                                                                               
   |             ----^^^^^^                                                                                                                                                                          
   |             |
   |             help: remove this `mut`
```