### PR TITLE
Remove the need for --test-threads=1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,9 @@
 # https://github.com/starkat99/appveyor-rust
 version: "{build}"
 os: Visual Studio 2015
+branches:
+  only:
+    - master
 environment:
   matrix:
     - channel: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: rust
 rust:
   - stable
   - nightly
-script: cargo test --no-fail-fast -- --test-threads=1
+script:
+  - cargo test --tests --no-fail-fast
+  # TODO: doctests are still flickering without --test-threads=1
+  - cargo test --doc --no-fail-fast -- --test-threads=1
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: rust
 rust:
   - stable
   - nightly
+branches:
+  only:
+    - master
 script:
   - cargo test --tests --no-fail-fast
   # TODO: doctests are still flickering without --test-threads=1

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Before upgrading, make sure to check out the [changelog](https://github.com/lipa
 Run tests:
 
 ```
-cargo test --no-fail-fast -- --test-threads=1
+cargo test --no-fail-fast
 ```
 
 Generate docs:

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -589,3 +589,18 @@ fn test_request_from_thread() {
 
     mock.assert();
 }
+
+#[test]
+fn test_mock_from_inside_thread_does_not_lock_forever() {
+    let _mock_outside_thread = mock("GET", "/").with_body("outside").create();
+
+    let process = thread::spawn(move || {
+        let _mock_inside_thread = mock("GET", "/").with_body("inside").create();
+    });
+
+    process.join().unwrap();
+
+    let (_, _, body) = request("GET /", "");
+
+    assert_eq!("outside", body);
+}


### PR DESCRIPTION
...by ensuring internally that tests creating mocks run sequentially.

A simpler, less intrusive alternative to https://github.com/lipanski/mockito/pull/34