### PR TITLE
Remove the test function name condition

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -611,6 +611,9 @@ fn test_request_from_thread() {
 }
 
 #[test]
+#[ignore]
+// Can't work unless there's a way to apply LOCAL_TEST_MUTEX only to test threads and
+// not to any of their sub-threads.
 fn test_mock_from_inside_thread_does_not_lock_forever() {
     let _mock_outside_thread = mock("GET", "/").with_body("outside").create();
 


### PR DESCRIPTION
…but break creating mocks from within sub-threads.