### PR TITLE
'Or' Matcher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,6 +469,7 @@ pub fn start() {
 /// These matchers are used within the `mock` and `Mock::match_header` calls.
 ///
 #[derive(Clone, PartialEq, Debug)]
+#[allow(deprecated)] // Rust bug #38832
 pub enum Matcher {
     /// Matches the exact path or header value. There's also an implementation of `From<&str>`
     /// to keep things simple and backwards compatible.
@@ -496,6 +497,7 @@ impl<'a> From<&'a str> for Matcher {
 
 impl PartialEq<String> for Matcher {
     fn eq(&self, other: &String) -> bool {
+        #[allow(deprecated)]
         match self {
             &Matcher::Exact(ref value) => { value == other },
             &Matcher::Regex(ref regex) => { Regex::new(regex).unwrap().is_match(other) },
@@ -769,6 +771,7 @@ impl Drop for Mock {
 }
 
 impl fmt::Display for Mock {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut formatted = String::new();
 
@@ -869,7 +872,7 @@ impl fmt::Display for Mock {
                 formatted.push_str("\r\n")
             },
             Matcher::Missing => formatted.push_str("(missing)\r\n"),
-            _ => {},
+            Matcher::Any => {}
         }
 
         write!(f, "{}", formatted)

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::fmt::Display;
 use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
-use {Matcher, SERVER_ADDRESS, Request, Mock};
+use {SERVER_ADDRESS, Request, Mock};
 
 impl Mock {
     fn method_matches(&self, request: &Request) -> bool {
@@ -15,22 +15,10 @@ impl Mock {
     }
 
     fn headers_match(&self, request: &Request) -> bool {
-        for &(ref field, ref value) in &self.headers {
-            match request.find_header(field) {
-                Some(request_header_value) => {
-                    if value == request_header_value { continue }
-
-                    return false
-                },
-                None => {
-                    if value == &Matcher::Missing { continue }
-
-                    return false
-                },
-            }
-        }
-
-        true
+        self.headers.iter().all(|&(ref field, ref expected)| {
+            let value = request.find_header(field);
+            *expected == value
+        })
     }
 
     fn body_matches(&self, request: &Request) -> bool {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -435,6 +435,28 @@ fn test_regex_match_header() {
 }
 
 #[test]
+fn test_or_match_header() {
+    let _m = mock("GET", "/")
+        .match_header("Via", Matcher::Or(
+            Box::new(Matcher::Exact("one".into())),
+            Box::new(Matcher::Exact("two".into()))))
+        .with_body("{}")
+        .create();
+
+    let (_, _, body_json) = request("GET /", "Via: one\r\n");
+    assert_eq!("{}", body_json);
+
+    let (_, _, body_json) = request("GET /", "Via: two\r\n");
+    assert_eq!("{}", body_json);
+
+    let (_, _, body_json) = request("GET /", "Via: one\r\nVia: two\r\n");
+    assert_eq!("{}", body_json);
+
+    let (status_line, _, _) = request("GET /", "Via: wrong\r\n");
+    assert!(status_line.starts_with("HTTP/1.1 501 "));
+}
+
+#[test]
 fn test_large_utf8_body() {
     let mock_body: String = rand::thread_rng()
         .gen_iter::<char>()


### PR DESCRIPTION
Allows combining of matchers into "one or the other" expression.

Implements `PartialEq` on `Option<&str>` instead of `String`, which removes need to check for `Missing` separately.


