### PR TITLE
Multivalued headers

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -33,8 +33,10 @@ impl Request {
         self.error.as_ref()
     }
 
-    pub fn find_header(&self, searched_field: &str) -> Option<&String> {
-        self.headers.iter().find(|&&(ref field, _)| field == searched_field).and_then(|&(_, ref value)| Some(value))
+    pub fn find_header_values(&self, searched_field: &str) -> Vec<&str> {
+        self.headers.iter().filter(|&&(ref field, _)| field == searched_field)
+            .map(|&(_, ref value)| value.as_str())
+            .collect()
     }
 
     fn is_parsed(&self) -> bool {

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,18 +11,17 @@ impl Mock {
     }
 
     fn path_matches(&self, request: &Request) -> bool {
-        self.path == request.path
+        self.path.matches_value(&request.path)
     }
 
     fn headers_match(&self, request: &Request) -> bool {
         self.headers.iter().all(|&(ref field, ref expected)| {
-            let value = request.find_header(field);
-            *expected == value
+            expected.matches_values(&request.find_header_values(field))
         })
     }
 
     fn body_matches(&self, request: &Request) -> bool {
-        self.body == String::from_utf8_lossy(&request.body).into_owned()
+        self.body.matches_value(&String::from_utf8_lossy(&request.body))
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -452,6 +452,9 @@ fn test_or_match_header() {
     let (_, _, body_json) = request("GET /", "Via: one\r\nVia: two\r\n");
     assert_eq!("{}", body_json);
 
+    let (status_line, _, _) = request("GET /", "Via: one\r\nVia: two\r\nVia: wrong\r\n");
+    assert!(status_line.starts_with("HTTP/1.1 501 "));
+
     let (status_line, _, _) = request("GET /", "Via: wrong\r\n");
     assert!(status_line.starts_with("HTTP/1.1 501 "));
 }
@@ -468,10 +471,19 @@ fn test_or_miss_match_header() {
     let (_, _, body_json) = request("GET /", "Via: one\r\n");
     assert_eq!("{}", body_json);
 
-    let (_, _, body_json) = request("GET /", "NotVia: two\r\n");
+    let (_, _, body_json) = request("GET /", "Via: one\r\nVia: one\r\nVia: one\r\n");
+    assert_eq!("{}", body_json);
+
+    let (_, _, body_json) = request("GET /", "NotVia: one\r\n");
     assert_eq!("{}", body_json);
 
     let (status_line, _, _) = request("GET /", "Via: wrong\r\n");
+    assert!(status_line.starts_with("HTTP/1.1 501 "));
+
+    let (status_line, _, _) = request("GET /", "Via: wrong\r\nVia: one\r\n");
+    assert!(status_line.starts_with("HTTP/1.1 501 "));
+
+    let (status_line, _, _) = request("GET /", "Via: one\r\nVia: wrong\r\n");
     assert!(status_line.starts_with("HTTP/1.1 501 "));
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -437,9 +437,9 @@ fn test_regex_match_header() {
 #[test]
 fn test_or_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Via", Matcher::Or(
-            Box::new(Matcher::Exact("one".into())),
-            Box::new(Matcher::Exact("two".into()))))
+        .match_header("Via", Matcher::AnyOf(vec![
+            Matcher::Exact("one".into()),
+            Matcher::Exact("two".into())]))
         .with_body("{}")
         .create();
 
@@ -462,9 +462,9 @@ fn test_or_match_header() {
 #[test]
 fn test_or_miss_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Via", Matcher::Or(
-            Box::new(Matcher::Exact("one".into())),
-            Box::new(Matcher::Missing)))
+        .match_header("Via", Matcher::AnyOf(vec![
+            Matcher::Exact("one".into()),
+            Matcher::Missing]))
         .with_body("{}")
         .create();
 


### PR DESCRIPTION
The `Via` header supports multiple values only as separate headers, so to test it, it's necessary to support multiple values per header.

At this point matching with `PartialEq` was getting too wild, so I've just changed it to a regular method.

