### PR TITLE
Uppercase the incoming request method

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -95,7 +95,7 @@ impl<'a> From<&'a mut TcpStream> for Request {
             request.error = Some(parser.error().to_string());
         } else {
             request.version = parser.http_version();
-            request.method = parser.http_method().to_string();
+            request.method = parser.http_method().to_string().to_uppercase();
         }
 
         request


### PR DESCRIPTION
When running tests using mockito in win-64, incoming requests frequently parse as `<unknown>` for some reason. To allow our tests to run and pass in win-64, we would like to be able to match `<unknown>`, but that is not currently possible because the mocked method is converted to uppercase (in `Mock::new()`).

This PR converts the incoming request to uppercase, so that `<unknown>` --> `<UNKNOWN>`, and we can match against it.