### PR TITLE
Precise listening notification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -471,8 +471,7 @@ pub fn mock<P: Into<Matcher>>(method: &str, path: P) -> Mock {
 pub fn reset() {
     server::try_start();
 
-    let state_mutex = server::STATE.clone();
-    let mut state = state_mutex.lock().unwrap();
+    let mut state = server::STATE.lock().unwrap();
     state.mocks.clear();
 }
 
@@ -727,8 +726,7 @@ impl Mock {
         let mut opt_message = None;
 
         {
-            let state_mutex = server::STATE.clone();
-            let state = state_mutex.lock().unwrap();
+            let state = server::STATE.lock().unwrap();
 
             if let Some(remote_mock) = state.mocks.iter().find(|mock| mock.id == self.id) {
                 opt_hits = Some(remote_mock.hits);
@@ -769,8 +767,7 @@ impl Mock {
         // Ensures Mockito tests are run sequentially.
         LOCAL_TEST_MUTEX.with(|_| {});
 
-        let state_mutex = server::STATE.clone();
-        let mut state = state_mutex.lock().unwrap();
+        let mut state = server::STATE.lock().unwrap();
 
         let mut remote_mock = self.clone();
         remote_mock.is_remote = true;
@@ -789,8 +786,7 @@ impl Mock {
 impl Drop for Mock {
     fn drop(&mut self) {
         if self.is_local() {
-            let state_mutex = server::STATE.clone();
-            let mut state = state_mutex.lock().unwrap();
+            let mut state = server::STATE.lock().unwrap();
 
             if let Some(pos) = state.mocks.iter().position(|mock| mock.id == self.id) {
                 state.mocks.remove(pos);

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use std::thread;
 use std::io::Write;
 use std::fmt::Display;
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use {SERVER_ADDRESS, Request, Mock};
 
 impl Mock {
@@ -51,7 +51,7 @@ impl Default for State {
 }
 
 lazy_static! {
-    pub static ref STATE: Arc<Mutex<State>> = Arc::new(Mutex::new(State::default()));
+    pub static ref STATE: Mutex<State> = Mutex::new(State::default());
 }
 
 pub fn try_start() {
@@ -61,8 +61,7 @@ pub fn try_start() {
 }
 
 fn start() {
-    let state_mutex = STATE.clone();
-    let mut state = state_mutex.lock().unwrap();
+    let mut state = STATE.lock().unwrap();
 
     if state.is_listening { return }
 
@@ -102,8 +101,7 @@ fn handle_request(request: Request, stream: TcpStream) {
 fn handle_match_mock(request: Request, stream: TcpStream) {
     let found;
 
-    let state_mutex = STATE.clone();
-    let mut state = state_mutex.lock().unwrap();
+    let mut state = STATE.lock().unwrap();
 
     if let Some(mock) = state.mocks.iter_mut().rev().find(|mock| mock == &request) {
         debug!("Mock found");


### PR DESCRIPTION
Busy-looping `while !is_listening() {}` wasn't very nice. 

Additionally, it'd say `true` when the port was used by another application, which lead to misleading test failures.

