### PR TITLE
Use auto-assigned port

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -7,10 +7,10 @@ use std::net::TcpStream;
 use std::io::{Read, Write, BufRead, BufReader};
 use std::str::FromStr;
 use test::Bencher;
-use mockito::{SERVER_ADDRESS, mock, reset};
+use mockito::{server_address, mock, reset};
 
 fn request_stream(route: &str, headers: &str) -> TcpStream {
-    let mut stream = TcpStream::connect(SERVER_ADDRESS).unwrap();
+    let mut stream = TcpStream::connect(server_address()).unwrap();
     let message = [route, " HTTP/1.1\r\n", headers, "\r\n"].join("");
     stream.write_all(message.as_bytes()).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! # Getting Started
 //!
-//! Using compiler flags, set the URL of your web client to `mockito::SERVER_URL` or `mockito::SERVER_ADDRESS`.
+//! Using compiler flags, set the URL of your web client to address returned by `mockito::server_url()` or `mockito::server_address()`.
 //!
 //! ## Example
 //!
@@ -19,10 +19,10 @@
 //! use mockito;
 //!
 //! #[cfg(not(test))]
-//! const URL: &str = "https://api.twitter.com";
+//! let url = "https://api.twitter.com";
 //!
 //! #[cfg(test)]
-//! const URL: &str = mockito::SERVER_URL;
+//! let url = &mockito::server_url();
 //! ```
 //!
 //! Then start mocking:
@@ -94,13 +94,13 @@
 //! ```no_run
 //! use std::net::TcpStream;
 //! use std::io::{Read, Write};
-//! use mockito::{mock, SERVER_ADDRESS};
+//! use mockito::{mock, server_address};
 //!
 //! let mock = mock("GET", "/hello").create();
 //!
 //! {
 //!     // Place a request
-//!     let mut stream = TcpStream::connect(SERVER_ADDRESS).unwrap();
+//!     let mut stream = TcpStream::connect(server_address()).unwrap();
 //!     stream.write_all("GET /hello HTTP/1.1\r\n\r\n".as_bytes()).unwrap();
 //!     let mut response = String::new();
 //!     stream.read_to_string(&mut response).unwrap();
@@ -117,13 +117,13 @@
 //! ```no_run
 //! use std::net::TcpStream;
 //! use std::io::{Read, Write};
-//! use mockito::{mock, SERVER_ADDRESS};
+//! use mockito::{mock, server_address};
 //!
 //! let mock = mockito::mock("GET", "/hello").expect(3).create();
 //!
 //! for _ in 0..3 {
 //!     // Place a request
-//!     let mut stream = TcpStream::connect(SERVER_ADDRESS).unwrap();
+//!     let mut stream = TcpStream::connect(server_address()).unwrap();
 //!     stream.write_all("GET /hello HTTP/1.1\r\n\r\n".as_bytes()).unwrap();
 //!     let mut response = String::new();
 //!     stream.read_to_string(&mut response).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 //!
 //! Mockito is a library for creating HTTP mocks to be used in integration tests or for offline work.
-//! It runs an HTTP server on your local port 1234 which delivers, creates and remove the mocks.
+//! It runs an HTTP server on a local port which delivers, creates and remove the mocks.
 //!
 //! The server is run on a separate thread within the same process and will be removed
 //! at the end of the run.
@@ -439,12 +439,18 @@ thread_local!(
 /// Points to the address the mock server is running at.
 /// Can be used with `std::net::TcpStream`.
 ///
-pub const SERVER_ADDRESS: &str = "127.0.0.1:1234";
+#[deprecated(note="Call server_address() instead")]
+pub const SERVER_ADDRESS: &str = SERVER_ADDRESS_INTERNAL;
+const SERVER_ADDRESS_INTERNAL: &str = "127.0.0.1:1234";
 
 ///
 /// Points to the URL the mock server is running at.
 ///
+#[deprecated(note="Call server_url() instead")]
 pub const SERVER_URL: &str = "http://127.0.0.1:1234";
+
+pub use server::server_address;
+pub use server::server_url;
 
 ///
 /// Initializes a mock for the provided `method` and `path`.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,10 +9,10 @@ use std::mem;
 use std::thread;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
-use mockito::{SERVER_ADDRESS, mock, Matcher};
+use mockito::{server_address, mock, Matcher};
 
 fn request_stream(route: &str, headers: &str, body: &str) -> TcpStream {
-    let mut stream = TcpStream::connect(SERVER_ADDRESS).unwrap();
+    let mut stream = TcpStream::connect(server_address()).unwrap();
     let message = [route, " HTTP/1.1\r\n", headers, "\r\n", body].join("");
     stream.write_all(message.as_bytes()).unwrap();
 
@@ -60,7 +60,7 @@ fn request_with_body(route: &str, headers: &str, body: &str) -> (String, Vec<Str
 fn test_create_starts_the_server() {
     let _m = mock("GET", "/").with_body("hello").create();
 
-    let stream = TcpStream::connect(SERVER_ADDRESS);
+    let stream = TcpStream::connect(server_address());
     assert!(stream.is_ok());
 }
 


### PR DESCRIPTION
This change makes mockito use a random free port assigned by the operating system.

The upside is that the port number won't conflict with any application, including other test processes that might be running in parallel.

The downside is that it's no longer possible to have `SERVER_ADDRESS` as a constant. It has to be a function call, so it's a breaking change.