### PR TITLE
Fix request parsing (fixes #60)

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -51,6 +51,34 @@ impl Request {
             self.headers.push((last_header_field.to_lowercase(), last_header_value));
         }
     }
+
+    fn content_length(&self) -> usize {
+        use std::str::FromStr;
+
+        self.find_header_values("content-length")
+            .first()
+            .and_then(|len| usize::from_str(*len).ok())
+            .unwrap_or(0)
+    }
+
+    fn read_request_body(&mut self, stream: &mut TcpStream) {
+        let expected_content_length = self.content_length();
+
+        loop {
+            if self.body.len() == expected_content_length {
+                break;
+            }
+
+            let mut body_buf = [0; 1024];
+
+            let body_read_len = stream.read(&mut body_buf).unwrap_or_else(|e| {
+                self.error = Some(e.to_string());
+                0
+            });
+
+            self.body.extend_from_slice(&body_buf[..body_read_len]);
+        }
+    }
 }
 
 impl Default for Request {
@@ -72,36 +100,71 @@ impl Default for Request {
 impl<'a> From<&'a mut TcpStream> for Request {
     fn from(stream: &mut TcpStream) -> Self {
         let mut request = Self::default();
-        let mut buf = [0; 1024];
 
-        let rlen = match stream.read(&mut buf) {
-            Err(e) => Err(e.to_string()),
-            Ok(0)  => Err("Nothing to read.".into()),
-            Ok(i)  => Ok(i)
-        }.map_err(|e| request.error = Some(e)).unwrap_or(0);
-        if rlen == 0 {
-            return request;
+        let mut all_buf = Vec::new();
+
+        loop {
+            if request.is_parsed {
+                break;
+            }
+
+            let mut headers = [httparse::EMPTY_HEADER; 16];
+            let mut req = httparse::Request::new(&mut headers);
+            let mut buf = [0; 1024];
+
+            let rlen = match stream.read(&mut buf) {
+                Err(e) => Err(e.to_string()),
+                Ok(0) => Err("Nothing to read.".into()),
+                Ok(i) => Ok(i),
+            }
+            .map_err(|e| request.error = Some(e))
+            .unwrap_or(0);
+
+            if rlen == 0 {
+                break;
+            }
+
+            all_buf.extend_from_slice(&buf[..rlen]);
+
+            let _ = req
+                .parse(&all_buf)
+                .map_err(|e| {
+                    request.error = Some(e.to_string());
+                })
+                .and_then(|status| match status {
+                    httparse::Status::Complete(head_len) => {
+                        if let Some(a @ 0...1) = req.version {
+                            request.version = (1, a)
+                        }
+                        if let Some(a) = req.method {
+                            request.method += a
+                        }
+                        if let Some(a) = req.path {
+                            request.path += a
+                        }
+                        for h in req.headers {
+                            request.last_header_field = Some(h.name.to_lowercase());
+                            request.last_header_value =
+                                Some(String::from_utf8_lossy(h.value).to_string());
+
+                            request.record_last_header();
+                        }
+
+                        request.body.extend_from_slice(&all_buf[head_len..]);
+
+                        let more_body_to_read = all_buf.len() < head_len + request.content_length();
+
+                        if more_body_to_read {
+                            request.read_request_body(stream);
+                        }
+                        request.is_parsed = true;
+
+                        Ok(())
+                    }
+                    httparse::Status::Partial => Ok(()),
+                });
         }
 
-        let mut headers = [httparse::EMPTY_HEADER; 16];
-        let mut req = httparse::Request::new(&mut headers);
-        let _ = req.parse(&buf).map_err(|e|{
-            request.error = Some(e.to_string());
-        }).and_then(|p| {
-            if let Some(a @ 0 ... 1) = req.version { request.version = (1,a) }
-            if let Some(a)           = req.method  { request.method += a }
-            if let Some(a)           = req.path    { request.path += a }
-            for h in req.headers {
-                request.last_header_field = Some(h.name.to_lowercase());
-                request.last_header_value = Some(String::from_utf8_lossy(h.value).into());
-                request.record_last_header();
-            }
-            if let httparse::Status::Complete(plen) = p {
-                request.is_parsed = true;
-                request.body.extend_from_slice(&buf[plen..rlen]);
-            }
-            Ok(())
-        });
         request
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -263,6 +263,27 @@ fn test_match_body_with_json() {
 }
 
 #[test]
+fn test_match_body_with_more_headers_with_json() {
+    let _m = mock("POST", "/")
+        .match_body(Matcher::Json(json!({"hello":"world", "foo": "bar"})))
+        .create();
+
+    let headers = (0..15)
+        .map(|n| {
+            format!(
+                "x-header-{}: foo-bar-value-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+                n
+            )
+        })
+        .collect::<Vec<String>>()
+        .join("\r\n");
+
+    let (status, _, _) =
+        request_with_body("POST /", &headers, r#"{"hello":"world", "foo": "bar"}"#);
+    assert_eq!("HTTP/1.1 200 OK\r\n", status);
+}
+
+#[test]
 fn test_match_body_with_json_order() {
     let _m = mock("POST", "/")
         .match_body(Matcher::Json(json!({"foo": "bar", "hello": "world"})))


### PR DESCRIPTION
While investigating issue #60, I found that at times not the entire request body is read after one `stream.read` call. I noticed that from time to time code was reading only 123 bytes out of 125. Remaining 2 bytes were making request body JSON impossible to parse which has resulted into the error that I've reported in comments for #60.

I also noticed that current implementation does not allow reading requests that are longer than 1024 bytes. I've tried to address it.

Another issue that I found is that even parser status is `httparse::Status::Complete`, it does not mean that entire body was read already. It should be fixed in proposed PR as well. 

It is tricky to automate testing of scenario when not entire request is read in one take, since it's random. Instead I've added a test that ensures that we can parse request that is longer than 1024 bytes.