### PR TITLE
Support HTTP/1.0 and working without Content-Length

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -10,7 +10,7 @@ use httparse;
 
 #[derive(Debug)]
 pub struct Request {
-    version: (u8, u8),
+    pub version: (u8, u8),
     pub method: String,
     pub path: String,
     pub headers: Vec<(String, String)>,

--- a/src/request.rs
+++ b/src/request.rs
@@ -56,29 +56,32 @@ impl Request {
         }
     }
 
-    fn content_length(&self) -> usize {
+    fn content_length(&self) -> Option<usize> {
         use std::str::FromStr;
 
         self.find_header_values("content-length")
             .first()
             .and_then(|len| usize::from_str(*len).ok())
-            .unwrap_or(0)
     }
 
     fn read_request_body(&mut self, stream: &mut TcpStream) {
         let expected_content_length = self.content_length();
 
         loop {
-            if self.body.len() == expected_content_length {
+            if expected_content_length.map_or(false, |exp| self.body.len() == exp) {
                 break;
             }
 
             let mut body_buf = [0; 1024];
 
-            let body_read_len = stream.read(&mut body_buf).unwrap_or_else(|e| {
-                self.error = Some(e.to_string());
-                0
-            });
+            let body_read_len = match stream.read(&mut body_buf) {
+                Ok(0) => break,
+                Ok(read) => read,
+                Err(err) => {
+                    self.error = Some(err.to_string());
+                    break;
+                }
+            };
 
             self.body.extend_from_slice(&body_buf[..body_read_len]);
         }
@@ -156,11 +159,14 @@ impl<'a> From<&'a mut TcpStream> for Request {
 
                         request.body.extend_from_slice(&all_buf[head_len..]);
 
-                        let more_body_to_read = all_buf.len() < head_len + request.content_length();
-
-                        if more_body_to_read {
-                            request.read_request_body(stream);
+                        match request.content_length() {
+                            Some(content_length) if all_buf.len() < head_len + content_length =>
+                                request.read_request_body(stream),
+                            None if request.version == (1, 0) =>
+                                request.read_request_body(stream),
+                            _ => {}
                         }
+
                         request.is_parsed = true;
 
                         Ok(())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -11,9 +11,9 @@ use rand::distributions::Alphanumeric;
 use rand::Rng;
 use mockito::{server_address, mock, Matcher};
 
-fn request_stream(route: &str, headers: &str, body: &str) -> TcpStream {
+fn request_stream(version: &str, route: &str, headers: &str, body: &str) -> TcpStream {
     let mut stream = TcpStream::connect(server_address()).unwrap();
-    let message = [route, " HTTP/1.1\r\n", headers, "\r\n", body].join("");
+    let message = [route, " HTTP/", version, "\r\n", headers, "\r\n", body].join("");
     stream.write_all(message.as_bytes()).unwrap();
 
     stream
@@ -50,12 +50,12 @@ fn parse_stream(stream: TcpStream, skip_body: bool) -> (String, Vec<String>, Str
 }
 
 fn request(route: &str, headers: &str) -> (String, Vec<String>, String) {
-    parse_stream(request_stream(route, headers, ""), route.starts_with("HEAD"))
+    parse_stream(request_stream("1.1", route, headers, ""), route.starts_with("HEAD"))
 }
 
 fn request_with_body(route: &str, headers: &str, body: &str) -> (String, Vec<String>, String) {
     let headers = format!("{}content-length: {}\r\n", headers, body.len());
-    parse_stream(request_stream(route, &headers, body), false)
+    parse_stream(request_stream("1.1", route, &headers, body), false)
 }
 
 #[test]
@@ -722,4 +722,12 @@ fn test_head_request_with_overridden_content_length() {
     let (_, headers, _) = request("HEAD /", "");
 
     assert_eq!(vec![String::from("content-length: 100")], headers);
+}
+
+#[test]
+fn test_propagate_protocol_to_response() {
+    let _mock = mock("GET", "/").create();
+
+    let (status_line, _, _) = parse_stream(request_stream("1.0", "GET /", "", ""), true);
+    assert_eq!("HTTP/1.0 200 OK\r\n", status_line);
 }


### PR DESCRIPTION
* Propagate the version of HTTP protocol to a response.
* Handle large bodies without "Content-Length" (HTTP/1.0).