### PR TITLE
update rand dependency to 0.6.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "lipanski/mockito", branch = "master" }
 appveyor = { repository = "lipanski/mockito", branch = "master", service = "github" }
 
 [dependencies]
-rand = "^0.5.5"
+rand = "^0.6.0"
 httparse = "^1.3.3"
 regex = "^1.0.5"
 lazy_static = "^1.1.0"


### PR DESCRIPTION
Closes https://github.com/lipanski/mockito/issues/73.

All tests still pass, and the [changelog](https://github.com/rust-random/rand/blob/master/CHANGELOG.md#060---2018-11-14) of Rand don't mention any (relevant) breaking changes.