### PR TITLE
Move colored diff output to feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ regex = "^1.0.5"
 lazy_static = "^1.1.0"
 serde_json = "^1.0.17"
 difference = "^2.0"
-colored = "^1.6"
+colored = { version = "^1.6", optional = true }
 log = "0.4.6"
 percent-encoding = "^1.0.1"
 assert-json-diff = "^1.0.0"
+
+[features]
+default = ["color"]
+color = ["colored"]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,4 +1,5 @@
 use difference::{Difference, Changeset};
+#[cfg(feature = "color")]
 use colored::*;
 
 pub fn compare(expected: &str, actual: &str) -> String {
@@ -21,11 +22,19 @@ pub fn compare(expected: &str, actual: &str) -> String {
                     for (i, change) in diffs.iter().enumerate() {
                         match change {
                             Difference::Same(ref z) => {
+                                #[cfg(feature = "color")]
                                 result.push_str(&z.green().to_string());
+                                #[cfg(not(feature = "color"))]
+                                result.push_str(&z);
+
                                 if i < diffs.len() - 1 { result.push(' '); }
                             }
                             Difference::Add(ref z) => {
+                                #[cfg(feature = "color")]
                                 result.push_str(&z.white().on_green().to_string());
+                                #[cfg(not(feature = "color"))]
+                                result.push_str(&z);
+
                                 if i < diffs.len() - 1 { result.push(' '); }
                             }
                             _ => (),
@@ -33,12 +42,20 @@ pub fn compare(expected: &str, actual: &str) -> String {
                     }
                     result.push('\n');
                 } else {
+                    #[cfg(feature = "color")]
                     result.push_str(&x.bright_green().to_string());
+                    #[cfg(not(feature = "color"))]
+                    result.push_str(&x);
+
                     result.push('\n');
                 }
             },
             Difference::Rem(ref x) => {
+                #[cfg(feature = "color")]
                 result.push_str(&x.red().to_string());
+                #[cfg(not(feature = "color"))]
+                result.push_str(&x);
+
                 result.push('\n');
             },
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,9 @@
 //!
 //! The errors produced by the `assert` method contain information about the tested mock, but also about the
 //! **last unmatched request**, which can be very useful to track down an error in your implementation or
-//! a missing or incomplete mock. A coloured diff is also displayed.
+//! a missing or incomplete mock. A colored diff is also displayed.
+//! 
+//! Color output is enabled by default, but can be toggled with the `color` feature flag.
 //!
 //! Here's an example of how a `Mock#assert` error looks like:
 //!
@@ -155,7 +157,7 @@
 //!
 //! > Difference:
 //!
-//! # A coloured diff
+//! # A colored diff
 //!
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,6 +470,7 @@ extern crate regex;
 #[macro_use] extern crate log;
 extern crate serde_json;
 extern crate difference;
+#[cfg(feature = "color")]
 extern crate colored;
 extern crate percent_encoding;
 extern crate assert_json_diff;


### PR DESCRIPTION
This allows one to use  this crate without bringing in the pretty big `colored` crate dependency and for when colored text diffs are not important.

The new `color` feature flag is enabled by default so no change in the default behavior