### PR TITLE
use the Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "HTTP mocking for Rust."
 keywords = ["mock", "mocks", "http", "webmock", "webmocks"]
 categories = ["development-tools::testing", "web-programming"]
 exclude = ["/.appveyor.yml", "/.travis.yml", "/benchmarks.txt", "/docs/", "/slides.pdf"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "lipanski/mockito", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,8 +522,8 @@ const SERVER_ADDRESS_INTERNAL: &str = "127.0.0.1:1234";
 #[deprecated(note="Call server_url() instead")]
 pub const SERVER_URL: &str = "http://127.0.0.1:1234";
 
-pub use server::address as server_address;
-pub use server::url as server_url;
+pub use crate::server::address as server_address;
+pub use crate::server::url as server_url;
 use assert_json_diff::{Comparison, assert_json_no_panic, Actual, Expected};
 
 ///

--- a/src/request.rs
+++ b/src/request.rs
@@ -165,7 +165,7 @@ impl<'a> From<&'a TcpStream> for Request {
                 })
                 .and_then(|status| match status {
                     httparse::Status::Complete(head_length) => {
-                        if let Some(a @ 0...1) = req.version {
+                        if let Some(a @ 0..=1) = req.version {
                             request.version = (1, a);
                         }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -13,7 +13,7 @@ pub(crate) struct Response {
 #[derive(Clone)]
 pub(crate) enum Body {
     Bytes(Vec<u8>),
-    Fn(Arc<Fn(&mut dyn io::Write) -> io::Result<()> + Send + Sync + 'static>),
+    Fn(Arc<dyn Fn(&mut dyn io::Write) -> io::Result<()> + Send + Sync + 'static>),
 }
 
 impl fmt::Debug for Body {

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,8 +5,8 @@ use std::fmt::Display;
 use std::net::{TcpListener, TcpStream, SocketAddr};
 use std::sync::Mutex;
 use std::sync::mpsc;
-use {SERVER_ADDRESS_INTERNAL, Request, Mock};
-use response::{Chunked, Body};
+use crate::{SERVER_ADDRESS_INTERNAL, Request, Mock};
+use crate::response::{Chunked, Body};
 
 impl Mock {
     fn method_matches(&self, request: &Request) -> bool {


### PR DESCRIPTION
I have just done the minimum steps outlined in the [Edition guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html#updating-your-code-to-be-compatible-with-the-new-edition) without edition idiom migration