### PR TITLE
Fix some edition idioms and run cargo fmt

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -2,12 +2,11 @@
 
 extern crate test;
 
-
+use mockito::{mock, reset, server_address};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
-use std::io::{Read, Write, BufRead, BufReader};
 use std::str::FromStr;
 use test::Bencher;
-use mockito::{server_address, mock, reset};
 
 fn request_stream(route: &str, headers: &str) -> TcpStream {
     let mut stream = TcpStream::connect(server_address()).unwrap();
@@ -29,7 +28,9 @@ fn parse_stream(stream: TcpStream) -> (String, Vec<String>, String) {
         let mut header_line = String::new();
         reader.read_line(&mut header_line).unwrap();
 
-        if header_line == "\r\n" { break }
+        if header_line == "\r\n" {
+            break;
+        }
 
         if header_line.starts_with("content-length:") {
             let mut parts = header_line.split(':');
@@ -40,7 +41,10 @@ fn parse_stream(stream: TcpStream) -> (String, Vec<String>, String) {
     }
 
     let mut body = String::new();
-    reader.take(content_length).read_to_string(&mut body).unwrap();
+    reader
+        .take(content_length)
+        .read_to_string(&mut body)
+        .unwrap();
 
     (status_line, headers, body)
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 extern crate test;
-extern crate mockito;
+
 
 use std::net::TcpStream;
 use std::io::{Read, Write, BufRead, BufReader};
@@ -36,7 +36,7 @@ fn parse_stream(stream: TcpStream) -> (String, Vec<String>, String) {
             content_length = u64::from_str(parts.nth(1).unwrap().trim()).unwrap();
         }
 
-        headers.push(header_line.trim_right().to_string());
+        headers.push(header_line.trim_end().to_string());
     }
 
     let mut body = String::new();

--- a/examples/mockito-server.rs
+++ b/examples/mockito-server.rs
@@ -1,4 +1,4 @@
-extern crate mockito;
+use mockito;
 
 use std::time::Duration;
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,6 +1,6 @@
-use difference::{Difference, Changeset};
 #[cfg(feature = "color")]
 use colored::*;
+use difference::{Changeset, Difference};
 
 pub fn compare(expected: &str, actual: &str) -> String {
     let mut result = String::new();
@@ -15,7 +15,7 @@ pub fn compare(expected: &str, actual: &str) -> String {
             Difference::Same(ref x) => {
                 result.push_str(x);
                 result.push('\n');
-            },
+            }
             Difference::Add(ref x) => {
                 if let Difference::Rem(ref y) = diffs[i - 1] {
                     let Changeset { diffs, .. } = Changeset::new(y, x, " ");
@@ -27,7 +27,9 @@ pub fn compare(expected: &str, actual: &str) -> String {
                                 #[cfg(not(feature = "color"))]
                                 result.push_str(&z);
 
-                                if i < diffs.len() - 1 { result.push(' '); }
+                                if i < diffs.len() - 1 {
+                                    result.push(' ');
+                                }
                             }
                             Difference::Add(ref z) => {
                                 #[cfg(feature = "color")]
@@ -35,7 +37,9 @@ pub fn compare(expected: &str, actual: &str) -> String {
                                 #[cfg(not(feature = "color"))]
                                 result.push_str(&z);
 
-                                if i < diffs.len() - 1 { result.push(' '); }
+                                if i < diffs.len() - 1 {
+                                    result.push(' ');
+                                }
                             }
                             _ => (),
                         }
@@ -49,7 +53,7 @@ pub fn compare(expected: &str, actual: &str) -> String {
 
                     result.push('\n');
                 }
-            },
+            }
             Difference::Rem(ref x) => {
                 #[cfg(feature = "color")]
                 result.push_str(&x.red().to_string());
@@ -57,7 +61,7 @@ pub fn compare(expected: &str, actual: &str) -> String {
                 result.push_str(&x);
 
                 result.push('\n');
-            },
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,17 +465,16 @@
 //! still be run in parallel.
 //!
 
-extern crate httparse;
-extern crate rand;
-extern crate regex;
+
+
+
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;
-extern crate serde_json;
-extern crate difference;
-#[cfg(feature = "color")]
-extern crate colored;
-extern crate percent_encoding;
-extern crate assert_json_diff;
+use serde_json;
+
+
+
+
 
 mod server;
 mod request;
@@ -999,7 +998,7 @@ impl Drop for Mock {
 
 impl fmt::Display for PathAndQueryMatcher {
     #[allow(deprecated)]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut formatted = String::new();
 
         match self {
@@ -1125,7 +1124,7 @@ impl fmt::Display for PathAndQueryMatcher {
 
 impl fmt::Display for Mock {
     #[allow(deprecated)]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut formatted = String::new();
 
         formatted.push_str("\r\n");

--- a/src/request.rs
+++ b/src/request.rs
@@ -202,7 +202,7 @@ impl<'a> From<&'a TcpStream> for Request {
 }
 
 impl fmt::Display for Request {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\r\n{} {}\r\n", &self.method, &self.path)?;
 
         for &(ref key, ref value) in &self.headers {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,10 +1,10 @@
-use std::io::{self, Read, BufRead, Cursor, BufReader};
-use std::mem;
-use std::str;
 use std::convert::From;
 use std::default::Default;
-use std::net::TcpStream;
 use std::fmt;
+use std::io::{self, BufRead, BufReader, Cursor, Read};
+use std::mem;
+use std::net::TcpStream;
+use std::str;
 
 use httparse;
 
@@ -39,20 +39,24 @@ impl Request {
     }
 
     pub fn find_header_values(&self, searched_field: &str) -> Vec<&str> {
-        self.headers.iter().filter_map(|(field, value)| {
-            if field == searched_field {
-                Some(value.as_str())
-            } else {
-                None
-            }
-        }).collect()
+        self.headers
+            .iter()
+            .filter_map(|(field, value)| {
+                if field == searched_field {
+                    Some(value.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     fn record_last_header(&mut self) {
         if self.last_header_field.is_some() && self.last_header_value.is_some() {
             let last_header_field = mem::replace(&mut self.last_header_field, None).unwrap();
             let last_header_value = mem::replace(&mut self.last_header_value, None).unwrap();
-            self.headers.push((last_header_field.to_lowercase(), last_header_value));
+            self.headers
+                .push((last_header_field.to_lowercase(), last_header_value));
         }
     }
 
@@ -65,7 +69,8 @@ impl Request {
     }
 
     fn has_chunked_body(&self) -> bool {
-        self.headers.iter()
+        self.headers
+            .iter()
             .filter(|(name, _)| name == "transfer-encoding")
             .any(|(_, value)| value.contains("chunked"))
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -17,7 +17,7 @@ pub(crate) enum Body {
 }
 
 impl fmt::Debug for Body {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Body::Bytes(ref b) => b.fmt(f),
             Body::Fn(_) => f.write_str("<callback>"),
@@ -217,7 +217,7 @@ impl From<usize> for Status {
 }
 
 impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let formatted = match self {
             Status::Continue => "100 Continue",
             Status::SwitchingProtocols => "101 Switching Protocols",

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
 use std::convert::From;
 use std::fmt;
 use std::io;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Response {
@@ -46,12 +46,12 @@ impl Default for Response {
 }
 
 pub(crate) struct Chunked<W: io::Write> {
-    writer: W
+    writer: W,
 }
 
 impl<W: io::Write> Chunked<W> {
     pub fn new(writer: W) -> Self {
-        Self {writer}
+        Self { writer }
     }
 
     pub fn finish(mut self) -> io::Result<W> {
@@ -65,7 +65,8 @@ impl<W: io::Write> io::Write for Chunked<W> {
         if buf.is_empty() {
             return Ok(0);
         }
-        self.writer.write_all(format!("{:x}\r\n", buf.len()).as_bytes())?;
+        self.writer
+            .write_all(format!("{:x}\r\n", buf.len()).as_bytes())?;
         self.writer.write_all(buf)?;
         self.writer.write_all(b"\r\n")?;
         Ok(buf.len())
@@ -77,7 +78,7 @@ impl<W: io::Write> io::Write for Chunked<W> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature="cargo-clippy", allow(clippy::pub_enum_variant_names))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::pub_enum_variant_names))]
 pub enum Status {
     Continue,
     SwitchingProtocols,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,12 +1,12 @@
-use std::thread;
+use crate::response::{Body, Chunked};
+use crate::{Mock, Request, SERVER_ADDRESS_INTERNAL};
+use std::fmt::Display;
 use std::io;
 use std::io::Write;
-use std::fmt::Display;
-use std::net::{TcpListener, TcpStream, SocketAddr};
-use std::sync::Mutex;
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc;
-use crate::{SERVER_ADDRESS_INTERNAL, Request, Mock};
-use crate::response::{Chunked, Body};
+use std::sync::Mutex;
+use std::thread;
 
 impl Mock {
     fn method_matches(&self, request: &Request) -> bool {
@@ -17,7 +17,6 @@ impl Mock {
         self.path.matches_value(&request.path)
     }
 
-
     fn headers_match(&self, request: &Request) -> bool {
         self.headers.iter().all(|&(ref field, ref expected)| {
             expected.matches_values(&request.find_header_values(field))
@@ -25,7 +24,8 @@ impl Mock {
     }
 
     fn body_matches(&self, request: &Request) -> bool {
-        self.body.matches_value(&String::from_utf8_lossy(&request.body))
+        self.body
+            .matches_value(&String::from_utf8_lossy(&request.body))
     }
 }
 
@@ -66,7 +66,9 @@ pub fn address() -> SocketAddr {
     try_start();
 
     let state = STATE.lock().map(|state| state.listening_addr);
-    state.expect("state lock").expect("server should be listening")
+    state
+        .expect("state lock")
+        .expect("server should be listening")
 }
 
 /// A local `http://…` URL of the server.
@@ -80,14 +82,13 @@ pub fn try_start() {
     let mut state = STATE.lock().unwrap();
 
     if state.listening_addr.is_some() {
-        return
+        return;
     }
 
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        let res = TcpListener::bind(SERVER_ADDRESS_INTERNAL)
-        .or_else(|err| {
+        let res = TcpListener::bind(SERVER_ADDRESS_INTERNAL).or_else(|err| {
             warn!("{}", err);
             TcpListener::bind("127.0.0.1:0")
         });
@@ -96,23 +97,25 @@ pub fn try_start() {
                 let addr = listener.local_addr().unwrap();
                 tx.send(Some(addr)).unwrap();
                 (listener, addr)
-            },
+            }
             Err(err) => {
                 error!("{}", err);
                 tx.send(None).unwrap();
                 return;
-            },
+            }
         };
 
         debug!("Server is listening at {}", addr);
         for stream in listener.incoming() {
-            if let Ok(stream) = stream{
+            if let Ok(stream) = stream {
                 let request = Request::from(&stream);
                 debug!("Request received: {}", request);
                 if request.is_ok() {
                     handle_request(request, stream);
                 } else {
-                    let message = request.error().map_or("Could not parse the request.", |err| err.as_str());
+                    let message = request
+                        .error()
+                        .map_or("Could not parse the request.", |err| err.as_str());
                     debug!("Could not parse request because: {}", message);
                     respond_with_error(stream, request.version, message);
                 }
@@ -145,7 +148,9 @@ fn handle_match_mock(request: Request, stream: TcpStream) {
         respond_with_mock_not_found(stream, request.version);
     }
 
-    if !found { state.unmatched_requests.push(request); }
+    if !found {
+        state.unmatched_requests.push(request);
+    }
 }
 
 fn respond(
@@ -153,7 +158,7 @@ fn respond(
     version: (u8, u8),
     status: impl Display,
     headers: Option<&Vec<(String, String)>>,
-    body: Option<&str>
+    body: Option<&str>,
 ) {
     let body = body.map(|s| Body::Bytes(s.as_bytes().to_owned()));
     if let Err(e) = respond_bytes(stream, version, status, headers, body.as_ref()) {
@@ -166,7 +171,7 @@ fn respond_bytes(
     version: (u8, u8),
     status: impl Display,
     headers: Option<&Vec<(String, String)>>,
-    body: Option<&Body>
+    body: Option<&Body>,
 ) -> io::Result<()> {
     let mut response = Vec::from(format!("HTTP/{}.{} {}\r\n", version.0, version.1, status));
     let mut has_content_length_header = false;
@@ -183,39 +188,46 @@ fn respond_bytes(
     }
 
     match body {
-        Some(Body::Bytes(bytes)) => if !has_content_length_header {
-            response.extend(format!("content-length: {}\r\n", bytes.len()).as_bytes());
-        },
+        Some(Body::Bytes(bytes)) => {
+            if !has_content_length_header {
+                response.extend(format!("content-length: {}\r\n", bytes.len()).as_bytes());
+            }
+        }
         Some(Body::Fn(_)) => {
             response.extend(b"transfer-encoding: chunked\r\n");
-        },
-        None => {},
+        }
+        None => {}
     };
     response.extend(b"\r\n");
     stream.write_all(&response)?;
     match body {
         Some(Body::Bytes(bytes)) => {
             stream.write_all(bytes)?;
-        },
+        }
         Some(Body::Fn(cb)) => {
             let mut chunked = Chunked::new(&mut stream);
             cb(&mut chunked)?;
             chunked.finish()?;
-        },
-        None => {},
+        }
+        None => {}
     };
     stream.flush()
 }
 
 fn respond_with_mock(stream: TcpStream, version: (u8, u8), mock: &Mock, skip_body: bool) {
-    let body =
-        if skip_body {
-            None
-        } else {
-            Some(&mock.response.body)
-        };
+    let body = if skip_body {
+        None
+    } else {
+        Some(&mock.response.body)
+    };
 
-    if let Err(e) = respond_bytes(stream, version, &mock.response.status, Some(&mock.response.headers), body) {
+    if let Err(e) = respond_bytes(
+        stream,
+        version,
+        &mock.response.status,
+        Some(&mock.response.headers),
+        body,
+    ) {
         eprintln!("warning: Mock response write error: {}", e);
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,5 @@
-extern crate rand;
-extern crate mockito;
+use rand;
+
 #[macro_use] extern crate serde_json;
 
 use std::net::{TcpStream, Shutdown};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,15 +1,16 @@
 use rand;
 
-#[macro_use] extern crate serde_json;
+#[macro_use]
+extern crate serde_json;
 
-use std::net::{TcpStream, Shutdown};
-use std::io::{Read, Write, BufRead, BufReader};
-use std::str::FromStr;
-use std::mem;
-use std::thread;
+use mockito::{mock, server_address, Matcher};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
-use mockito::{server_address, mock, Matcher};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::mem;
+use std::net::{Shutdown, TcpStream};
+use std::str::FromStr;
+use std::thread;
 
 fn request_stream(version: &str, route: &str, headers: &str, body: &str) -> TcpStream {
     let mut stream = TcpStream::connect(server_address()).unwrap();
@@ -32,7 +33,9 @@ fn parse_stream(stream: TcpStream, skip_body: bool) -> (String, Vec<String>, Str
         let mut header_line = String::new();
         reader.read_line(&mut header_line).unwrap();
 
-        if header_line == "\r\n" { break }
+        if header_line == "\r\n" {
+            break;
+        }
 
         if header_line.starts_with("transfer-encoding:") && header_line.contains("chunked") {
             is_chunked = true;
@@ -49,20 +52,29 @@ fn parse_stream(stream: TcpStream, skip_body: bool) -> (String, Vec<String>, Str
     let mut body = String::new();
     if !skip_body {
         if let Some(content_length) = content_length {
-            reader.take(content_length).read_to_string(&mut body).unwrap();
+            reader
+                .take(content_length)
+                .read_to_string(&mut body)
+                .unwrap();
         } else if is_chunked {
             let mut chunk_size_buf = String::new();
             loop {
                 chunk_size_buf.clear();
                 reader.read_line(&mut chunk_size_buf).unwrap();
 
-                let chunk_size = u64::from_str_radix(chunk_size_buf.trim_matches(|c| c == '\r' || c == '\n'), 16)
-                    .expect("chunk size");
+                let chunk_size = u64::from_str_radix(
+                    chunk_size_buf.trim_matches(|c| c == '\r' || c == '\n'),
+                    16,
+                )
+                .expect("chunk size");
                 if chunk_size == 0 {
                     break;
                 }
 
-                (&mut reader).take(chunk_size).read_to_string(&mut body).unwrap();
+                (&mut reader)
+                    .take(chunk_size)
+                    .read_to_string(&mut body)
+                    .unwrap();
 
                 chunk_size_buf.clear();
                 reader.read_line(&mut chunk_size_buf).unwrap();
@@ -74,7 +86,10 @@ fn parse_stream(stream: TcpStream, skip_body: bool) -> (String, Vec<String>, Str
 }
 
 fn request(route: &str, headers: &str) -> (String, Vec<String>, String) {
-    parse_stream(request_stream("1.1", route, headers, ""), route.starts_with("HEAD"))
+    parse_stream(
+        request_stream("1.1", route, headers, ""),
+        route.starts_with("HEAD"),
+    )
 }
 
 fn request_with_body(route: &str, headers: &str, body: &str) -> (String, Vec<String>, String) {
@@ -140,7 +155,9 @@ fn test_match_header() {
 
 #[test]
 fn test_match_header_is_case_insensitive_on_the_field_name() {
-    let _m = mock("GET", "/").match_header("content-type", "text/plain").create();
+    let _m = mock("GET", "/")
+        .match_header("content-type", "text/plain")
+        .create();
 
     let (uppercase_status_line, _, _) = request("GET /", "Content-Type: text/plain\r\n");
     assert_eq!("HTTP/1.1 200 OK\r\n", uppercase_status_line);
@@ -157,10 +174,16 @@ fn test_match_multiple_headers() {
         .with_body("matched")
         .create();
 
-    let (_, _, body_matching) = request("GET /", "content-type: text/plain\r\nauthorization: secret\r\n");
+    let (_, _, body_matching) = request(
+        "GET /",
+        "content-type: text/plain\r\nauthorization: secret\r\n",
+    );
     assert_eq!("matched", body_matching);
 
-    let (status_not_matching, _, _) = request("GET /", "content-type: text/plain\r\nauthorization: meh\r\n");
+    let (status_not_matching, _, _) = request(
+        "GET /",
+        "content-type: text/plain\r\nauthorization: meh\r\n",
+    );
     assert_eq!("HTTP/1.1 501 Mock Not Found\r\n", status_not_matching);
 }
 
@@ -250,9 +273,7 @@ fn test_match_any_body_by_default() {
 
 #[test]
 fn test_match_body() {
-    let _m = mock("POST", "/")
-        .match_body("hello")
-        .create();
+    let _m = mock("POST", "/").match_body("hello").create();
 
     let (status, _, _) = request_with_body("POST /", "", "hello");
     assert_eq!("HTTP/1.1 200 OK\r\n", status);
@@ -260,9 +281,7 @@ fn test_match_body() {
 
 #[test]
 fn test_match_body_not_matching() {
-    let _m = mock("POST", "/")
-        .match_body("hello")
-        .create();
+    let _m = mock("POST", "/").match_body("hello").create();
 
     let (status, _, _) = request_with_body("POST /", "", "bye");
     assert_eq!("HTTP/1.1 501 Mock Not Found\r\n", status);
@@ -290,12 +309,12 @@ fn test_match_body_with_regex_not_matching() {
 
 #[test]
 fn test_match_body_with_json() {
-   let _m = mock("POST", "/")
-       .match_body(Matcher::Json(json!({"hello":"world", "foo": "bar"})))
-       .create();
+    let _m = mock("POST", "/")
+        .match_body(Matcher::Json(json!({"hello":"world", "foo": "bar"})))
+        .create();
 
-   let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world", "foo": "bar"}"#);
-   assert_eq!("HTTP/1.1 200 OK\r\n", status);
+    let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world", "foo": "bar"}"#);
+    assert_eq!("HTTP/1.1 200 OK\r\n", status);
 }
 
 #[test]
@@ -331,18 +350,22 @@ fn test_match_body_with_json_order() {
 
 #[test]
 fn test_match_body_with_json_string() {
-   let _m = mock("POST", "/")
-       .match_body(Matcher::JsonString("{\"hello\":\"world\", \"foo\": \"bar\"}".to_string()))
-       .create();
+    let _m = mock("POST", "/")
+        .match_body(Matcher::JsonString(
+            "{\"hello\":\"world\", \"foo\": \"bar\"}".to_string(),
+        ))
+        .create();
 
-   let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world", "foo": "bar"}"#);
-   assert_eq!("HTTP/1.1 200 OK\r\n", status);
+    let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world", "foo": "bar"}"#);
+    assert_eq!("HTTP/1.1 200 OK\r\n", status);
 }
 
 #[test]
 fn test_match_body_with_json_string_order() {
     let _m = mock("POST", "/")
-        .match_body(Matcher::JsonString("{\"foo\": \"bar\", \"hello\": \"world\"}".to_string()))
+        .match_body(Matcher::JsonString(
+            "{\"foo\": \"bar\", \"hello\": \"world\"}".to_string(),
+        ))
         .create();
 
     let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world", "foo": "bar"}"#);
@@ -372,7 +395,9 @@ fn test_match_body_with_partial_json_and_extra_fields() {
 #[test]
 fn test_match_body_with_partial_json_string() {
     let _m = mock("POST", "/")
-        .match_body(Matcher::PartialJsonString("{\"hello\": \"world\"}".to_string()))
+        .match_body(Matcher::PartialJsonString(
+            "{\"hello\": \"world\"}".to_string(),
+        ))
         .create();
 
     let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world", "foo": "bar"}"#);
@@ -382,7 +407,9 @@ fn test_match_body_with_partial_json_string() {
 #[test]
 fn test_match_body_with_partial_json_string_and_extra_fields() {
     let _m = mock("POST", "/")
-        .match_body(Matcher::PartialJsonString("{\"foo\": \"bar\", \"hello\": \"world\"}".to_string()))
+        .match_body(Matcher::PartialJsonString(
+            "{\"foo\": \"bar\", \"hello\": \"world\"}".to_string(),
+        ))
         .create();
 
     let (status, _, _) = request_with_body("POST /", "", r#"{"hello":"world"}"#);
@@ -391,10 +418,7 @@ fn test_match_body_with_partial_json_string_and_extra_fields() {
 
 #[test]
 fn test_mock_with_status() {
-    let _m = mock("GET", "/")
-        .with_status(204)
-        .with_body("")
-        .create();
+    let _m = mock("GET", "/").with_status(204).with_body("").create();
 
     let (status_line, _, _) = request("GET /", "");
     assert_eq!("HTTP/1.1 204 No Content\r\n", status_line);
@@ -402,10 +426,7 @@ fn test_mock_with_status() {
 
 #[test]
 fn test_mock_with_custom_status() {
-    let _m = mock("GET", "/")
-        .with_status(333)
-        .with_body("")
-        .create();
+    let _m = mock("GET", "/").with_status(333).with_body("").create();
 
     let (status_line, _, _) = request("GET /", "");
     assert_eq!("HTTP/1.1 333 Custom\r\n", status_line);
@@ -413,9 +434,7 @@ fn test_mock_with_custom_status() {
 
 #[test]
 fn test_mock_with_body() {
-    let _m = mock("GET", "/")
-        .with_body("hello")
-        .create();
+    let _m = mock("GET", "/").with_body("hello").create();
 
     let (_, _, body) = request("GET /", "");
     assert_eq!("hello", body);
@@ -474,7 +493,8 @@ fn test_mock_preserves_header_order() {
     let _m = mock.create();
 
     let (_, headers, _) = request("GET /", "");
-    let custom_headers: Vec<_> = headers.into_iter()
+    let custom_headers: Vec<_> = headers
+        .into_iter()
         .filter(|header| header.starts_with("x-custom-header"))
         .collect();
 
@@ -524,8 +544,12 @@ fn test_explicitly_calling_drop_removes_the_mock() {
 
 #[test]
 fn test_regex_match_path() {
-    let _m1 = mock("GET", Matcher::Regex(r"^/a/\d{1}$".to_string())).with_body("aaa").create();
-    let _m2 = mock("GET", Matcher::Regex(r"^/b/\d{1}$".to_string())).with_body("bbb").create();
+    let _m1 = mock("GET", Matcher::Regex(r"^/a/\d{1}$".to_string()))
+        .with_body("aaa")
+        .create();
+    let _m2 = mock("GET", Matcher::Regex(r"^/b/\d{1}$".to_string()))
+        .with_body("bbb")
+        .create();
 
     let (_, _, body_a) = request("GET /a/1", "");
     assert_eq!("aaa", body_a);
@@ -543,7 +567,10 @@ fn test_regex_match_path() {
 #[test]
 fn test_regex_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Authorization", Matcher::Regex(r"^Bearer token\.\w+$".to_string()))
+        .match_header(
+            "Authorization",
+            Matcher::Regex(r"^Bearer token\.\w+$".to_string()),
+        )
         .with_body("{}")
         .create();
 
@@ -557,9 +584,13 @@ fn test_regex_match_header() {
 #[test]
 fn test_any_of_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Via", Matcher::AnyOf(vec![
-            Matcher::Exact("one".into()),
-            Matcher::Exact("two".into())]))
+        .match_header(
+            "Via",
+            Matcher::AnyOf(vec![
+                Matcher::Exact("one".into()),
+                Matcher::Exact("two".into()),
+            ]),
+        )
         .with_body("{}")
         .create();
 
@@ -584,7 +615,8 @@ fn test_any_of_match_body() {
     let _m = mock("GET", "/")
         .match_body(Matcher::AnyOf(vec![
             Matcher::Regex("one".to_string()),
-            Matcher::Regex("two".to_string())]))
+            Matcher::Regex("two".to_string()),
+        ]))
         .create();
 
     let (status_line, _, _) = request_with_body("GET /", "", "one");
@@ -603,9 +635,10 @@ fn test_any_of_match_body() {
 #[test]
 fn test_any_of_missing_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Via", Matcher::AnyOf(vec![
-            Matcher::Exact("one".into()),
-            Matcher::Missing]))
+        .match_header(
+            "Via",
+            Matcher::AnyOf(vec![Matcher::Exact("one".into()), Matcher::Missing]),
+        )
         .with_body("{}")
         .create();
 
@@ -631,9 +664,13 @@ fn test_any_of_missing_match_header() {
 #[test]
 fn test_all_of_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Via", Matcher::AllOf(vec![
-            Matcher::Regex("one".into()),
-            Matcher::Regex("two".into())]))
+        .match_header(
+            "Via",
+            Matcher::AllOf(vec![
+                Matcher::Regex("one".into()),
+                Matcher::Regex("two".into()),
+            ]),
+        )
         .with_body("{}")
         .create();
 
@@ -658,7 +695,8 @@ fn test_all_of_match_body() {
     let _m = mock("GET", "/")
         .match_body(Matcher::AllOf(vec![
             Matcher::Regex("one".to_string()),
-            Matcher::Regex("two".to_string())]))
+            Matcher::Regex("two".to_string()),
+        ]))
         .create();
 
     let (status_line, _, _) = request_with_body("GET /", "", "one");
@@ -677,8 +715,7 @@ fn test_all_of_match_body() {
 #[test]
 fn test_all_of_missing_match_header() {
     let _m = mock("GET", "/")
-        .match_header("Via", Matcher::AllOf(vec![
-            Matcher::Missing]))
+        .match_header("Via", Matcher::AllOf(vec![Matcher::Missing]))
         .with_body("{}")
         .create();
 
@@ -768,7 +805,9 @@ fn test_display_mock_matching_any_query() {
 
 #[test]
 fn test_display_mock_matching_exact_header() {
-    let mock = mock("GET", "/").match_header("content-type", "text").create();
+    let mock = mock("GET", "/")
+        .match_header("content-type", "text")
+        .create();
 
     assert_eq!("\r\nGET /\r\ncontent-type: text\r\n", format!("{}", mock));
 }
@@ -794,7 +833,9 @@ fn test_display_mock_matching_exact_body() {
 
 #[test]
 fn test_display_mock_matching_regex_body() {
-    let mock = mock("POST", "/").match_body(Matcher::Regex("hello".to_string())).create();
+    let mock = mock("POST", "/")
+        .match_body(Matcher::Regex("hello".to_string()))
+        .create();
 
     assert_eq!("\r\nPOST /\r\nhello\r\n", format!("{}", mock));
 }
@@ -808,9 +849,15 @@ fn test_display_mock_matching_any_body() {
 
 #[test]
 fn test_display_mock_matching_headers_and_body() {
-    let mock = mock("POST", "/").match_header("content-type", "text").match_body("hello").create();
+    let mock = mock("POST", "/")
+        .match_header("content-type", "text")
+        .match_body("hello")
+        .create();
 
-    assert_eq!("\r\nPOST /\r\ncontent-type: text\r\nhello\r\n", format!("{}", mock));
+    assert_eq!(
+        "\r\nPOST /\r\ncontent-type: text\r\nhello\r\n",
+        format!("{}", mock)
+    );
 }
 
 #[test]
@@ -866,7 +913,9 @@ fn test_assert_panics_with_too_many_requests() {
 }
 
 #[test]
-#[should_panic(expected = "\n> Expected 1 request(s) to:\n\r\nGET /hello\r\n\n...but received 0\n\n> The last unmatched request was:\n\r\nGET /bye\r\n\n> Difference:\n\n\u{1b}[31mGET /hello\u{1b}[0m\n\u{1b}[32mGET\u{1b}[0m \u{1b}[42;37m/bye\u{1b}[0m\n\n\n")]
+#[should_panic(
+    expected = "\n> Expected 1 request(s) to:\n\r\nGET /hello\r\n\n...but received 0\n\n> The last unmatched request was:\n\r\nGET /bye\r\n\n> Difference:\n\n\u{1b}[31mGET /hello\u{1b}[0m\n\u{1b}[32mGET\u{1b}[0m \u{1b}[42;37m/bye\u{1b}[0m\n\n\n"
+)]
 fn test_assert_with_last_unmatched_request() {
     let mock = mock("GET", "/hello").create();
 
@@ -876,7 +925,9 @@ fn test_assert_with_last_unmatched_request() {
 }
 
 #[test]
-#[should_panic(expected = "\n> Expected 1 request(s) to:\n\r\nGET /hello\r\n\n...but received 0\n\n> The last unmatched request was:\n\r\nGET /bye\r\nauthorization: 1234\r\naccept: text\r\n\n> Difference:\n\n\u{1b}[31mGET /hello\u{1b}[0m\n\u{1b}[32mGET\u{1b}[0m \u{1b}[42;37m/bye\nauthorization: 1234\naccept: text\u{1b}[0m\n\n\n")]
+#[should_panic(
+    expected = "\n> Expected 1 request(s) to:\n\r\nGET /hello\r\n\n...but received 0\n\n> The last unmatched request was:\n\r\nGET /bye\r\nauthorization: 1234\r\naccept: text\r\n\n> Difference:\n\n\u{1b}[31mGET /hello\u{1b}[0m\n\u{1b}[32mGET\u{1b}[0m \u{1b}[42;37m/bye\nauthorization: 1234\naccept: text\u{1b}[0m\n\n\n"
+)]
 fn test_assert_with_last_unmatched_request_and_headers() {
     let mock = mock("GET", "/hello").create();
 
@@ -886,7 +937,9 @@ fn test_assert_with_last_unmatched_request_and_headers() {
 }
 
 #[test]
-#[should_panic(expected = "\n> Expected 1 request(s) to:\n\r\nGET /hello\r\n\n...but received 0\n\n> The last unmatched request was:\n\r\nPOST /bye\r\ncontent-length: 5\r\nhello\r\n\n")]
+#[should_panic(
+    expected = "\n> Expected 1 request(s) to:\n\r\nGET /hello\r\n\n...but received 0\n\n> The last unmatched request was:\n\r\nPOST /bye\r\ncontent-length: 5\r\nhello\r\n\n"
+)]
 fn test_assert_with_last_unmatched_request_and_body() {
     let mock = mock("GET", "/hello").create();
 
@@ -928,7 +981,9 @@ fn test_mock_from_inside_thread_does_not_lock_forever() {
 
 #[test]
 fn test_head_request_with_overridden_content_length() {
-    let _mock = mock("HEAD", "/").with_header("content-length", "100").create();
+    let _mock = mock("HEAD", "/")
+        .with_header("content-length", "100")
+        .create();
 
     let (_, headers, _) = request("HEAD /", "");
 
@@ -950,9 +1005,7 @@ fn test_propagate_protocol_to_response() {
 fn test_large_body_without_content_length() {
     let body = "123".repeat(2048);
 
-    let _mock = mock("POST", "/")
-        .match_body(body.as_str())
-        .create();
+    let _mock = mock("POST", "/").match_body(body.as_str()).create();
 
     let stream = request_stream("1.0", "POST /", "", &body);
     stream.shutdown(Shutdown::Write).unwrap();
@@ -971,7 +1024,7 @@ fn test_transfer_encoding_chunked() {
 
     let (status, _, _) = parse_stream(
         request_stream("1.1", "POST /", "Transfer-Encoding: chunked\r\n", body),
-        false
+        false,
     );
 
     assert_eq!("HTTP/1.1 200 OK\r\n", status);
@@ -992,8 +1045,7 @@ fn test_match_exact_query() {
 
 #[test]
 fn test_match_exact_query_via_path() {
-    let _m = mock("GET", "/hello?number=one")
-        .create();
+    let _m = mock("GET", "/hello?number=one").create();
 
     let (status_line, _, _) = request("GET /hello?number=one", "");
     assert_eq!("HTTP/1.1 200 OK\r\n", status_line);
@@ -1028,12 +1080,10 @@ fn test_match_partial_query_by_urlencoded() {
 #[test]
 fn test_match_partial_query_by_regex_all_of() {
     let _m = mock("GET", "/hello")
-        .match_query(
-            Matcher::AllOf(vec![
-                Matcher::Regex("number=one".to_string()),
-                Matcher::Regex("hello=world".to_string())
-            ])
-        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::Regex("number=one".to_string()),
+            Matcher::Regex("hello=world".to_string()),
+        ]))
         .create();
 
     let (status_line, _, _) = request("GET /hello?hello=world&something=else&number=one", "");
@@ -1046,12 +1096,10 @@ fn test_match_partial_query_by_regex_all_of() {
 #[test]
 fn test_match_partial_query_by_urlencoded_all_of() {
     let _m = mock("GET", "/hello")
-        .match_query(
-            Matcher::AllOf(vec![
-                Matcher::UrlEncoded("num ber".into(), "o ne".into()),
-                Matcher::UrlEncoded("hello".into(), "world".into())
-            ])
-        )
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("num ber".into(), "o ne".into()),
+            Matcher::UrlEncoded("hello".into(), "world".into()),
+        ]))
         .create();
 
     let (status_line, _, _) = request("GET /hello?hello=world&something=else&num%20ber=o%20ne", "");
@@ -1063,9 +1111,7 @@ fn test_match_partial_query_by_urlencoded_all_of() {
 
 #[test]
 fn test_match_missing_query() {
-    let _m = mock("GET", "/hello")
-        .match_query(Matcher::Missing)
-        .create();
+    let _m = mock("GET", "/hello").match_query(Matcher::Missing).create();
 
     let (status_line, _, _) = request("GET /hello?", "");
     assert_eq!("HTTP/1.1 200 OK\r\n", status_line);
@@ -1076,13 +1122,11 @@ fn test_match_missing_query() {
 
 #[test]
 fn test_anyof_exact_path_and_query_matcher() {
-    let mock =
-        mock(
-            "GET",
-            Matcher::AnyOf(vec![
-                Matcher::Exact("/hello?world".to_string()),
-            ]),
-        ).create();
+    let mock = mock(
+        "GET",
+        Matcher::AnyOf(vec![Matcher::Exact("/hello?world".to_string())]),
+    )
+    .create();
 
     let (status_line, _, _) = request("GET /hello?world", "");
     assert_eq!("HTTP/1.1 200 OK\r\n", status_line);


### PR DESCRIPTION
I noticed that you did some formatting changes in 3b519bb.

To make it easier for contributors to adhere to a common style, would you be willing to use `cargo fmt`?
This would also make the code more consistent with other codebases using the same tool.