### PR TITLE
Bump dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ travis-ci = { repository = "lipanski/mockito", branch = "master" }
 appveyor = { repository = "lipanski/mockito", branch = "master", service = "github" }
 
 [dependencies]
-rand = "^0.7.0"
-httparse = "^1.3.3"
-regex = "^1.0.5"
-lazy_static = "^1.1.0"
-serde_json = "^1.0.17"
-difference = "^2.0"
-colored = { version = "^1.6", optional = true }
+rand = "0.7.0"
+httparse = "1.3.3"
+regex = "1.0.5"
+lazy_static = "1.1.0"
+serde_json = "1.0.17"
+difference = "2.0"
+colored = { version = "1.6", optional = true }
 log = "0.4.6"
-percent-encoding = "^1.0.1"
-assert-json-diff = "^1.0.0"
+percent-encoding = "2.1.0"
+assert-json-diff = "1.0.0"
 
 [features]
 default = ["color"]


### PR DESCRIPTION
Also `^` in Cargo doesn't do anything (it's the default behavior)