### PR TITLE
Add `Content-Length` header to null body

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -197,7 +197,11 @@ fn respond_bytes(
         Some(Body::Fn(_)) => {
             response.extend(b"transfer-encoding: chunked\r\n");
         }
-        None => {}
+        None => {
+            if !has_content_length_header {
+                response.extend(format!("content-length: 0\r\n").as_bytes());
+            }
+        }
     };
     response.extend(b"\r\n");
     stream.write_all(&response)?;


### PR DESCRIPTION
Especially in the case of the `501 Mock Not Found` response, because of the non-standard status line, it can be helpful to explicitly signal a null body so clients don't hang while expecting more