### PR TITLE
Add ability to attach a sequence of responses to a mock

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -4,10 +4,43 @@ use std::io;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct Response {
-    pub status: Status,
-    pub headers: Vec<(String, String)>,
-    pub body: Body,
+pub struct Response {
+    status: Status,
+    headers: Vec<(String, String)>,
+    body: Body,
+}
+
+impl Response {
+    pub fn with_status<I: Into<Status>>(mut self, status: I) -> Self {
+        self.status = status.into();
+        self
+    }
+    pub fn with_header(mut self, field: &str, value: &str) -> Self {
+        self.headers.push((field.to_owned(), value.to_owned()));
+        self
+    }
+    pub fn with_body<StrOrBytes: AsRef<[u8]>>(mut self, body: StrOrBytes) -> Self {
+        self.body = Body::Bytes(body.as_ref().to_owned());
+        self
+    }
+    pub(crate) fn status(&self) -> &Status {
+        &self.status
+    }
+    pub(crate) fn status_mut(&mut self) -> &mut Status {
+        &mut self.status
+    }
+    pub(crate) fn headers(&self) -> &Vec<(String, String)> {
+        &self.headers
+    }
+    pub(crate) fn headers_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.headers
+    }
+    pub(crate) fn body(&self) -> &Body {
+        &self.body
+    }
+    pub(crate) fn body_mut(&mut self) -> &mut Body {
+        &mut self.body
+    }
 }
 
 #[derive(Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -242,17 +242,18 @@ fn respond_bytes(
 }
 
 fn respond_with_mock(stream: TcpStream, version: (u8, u8), mock: &Mock, skip_body: bool) {
+    let idx = mock.hits - 1;
     let body = if skip_body {
         None
     } else {
-        Some(&mock.response.body)
+        Some(mock.response_at(idx).body())
     };
 
     if let Err(e) = respond_bytes(
         stream,
         version,
-        &mock.response.status,
-        Some(&mock.response.headers),
+        &mock.response_at(idx).status(),
+        Some(&mock.response_at(idx).headers()),
         body,
     ) {
         eprintln!("warning: Mock response write error: {}", e);


### PR DESCRIPTION
I was working on this before I saw you merge https://github.com/lipanski/mockito/commit/b0966f83cfab08c75b98bf06d18fefe8d710e888, so my apologies that this overlaps with that, and I totally understand if you wouldn't want to have both in the codebase. Unfortunately, the commit I just mentioned doesn't cover my use case so I'm opening this anyway.

As I mentioned in my  previous PR, I've been using mockito as part of an integration test suite, which means the code that sets up the mockito mocks is separate from the services that are sending requests, so I can't use `.assert()` to cause a mock to advance from one response to another. This commits allows the user to attach a sequence of `Response` objects to a mock. The mock will advance through the sequence with each request that matches that mock. When the mock reaches the end of the sequence, it will send the last response in the sequence for any additional requests that come in.

I tried to keep the API for attaching responses as minimal, and close to the style of the library as I could.