### PR TITLE
fix: use serde_urlencoded for query matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ serde_json = "1.0.17"
 difference = "2.0"
 colored = { version = "1.6", optional = true }
 log = "0.4.6"
-percent-encoding = "2.1.0"
 assert-json-diff = "1.0.3"
+serde_urlencoded = "0.6.1"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,15 +753,15 @@ impl Matcher {
                 let actual: serde_json::Value = serde_json::from_str(other).unwrap();
                 assert_json_include_no_panic(&actual, &expected).is_ok()
             }
-            Matcher::UrlEncoded(ref expected_field, ref expected_value) => serde_urlencoded::from_str::<HashMap<String, String>>(other)
-                .map(|params: HashMap<_, _>| {
-                    params
-                        .into_iter()
-                        .any(|(ref field, ref value)| {
+            Matcher::UrlEncoded(ref expected_field, ref expected_value) => {
+                serde_urlencoded::from_str::<HashMap<String, String>>(other)
+                    .map(|params: HashMap<_, _>| {
+                        params.into_iter().any(|(ref field, ref value)| {
                             field == expected_field && value == expected_value
                         })
-                })
-                .unwrap_or(false),
+                    })
+                    .unwrap_or(false)
+            }
             Matcher::Any => true,
             Matcher::AnyOf(ref matchers) => matchers.iter().any(|m| m.matches_value(other)),
             Matcher::AllOf(ref matchers) => matchers.iter().all(|m| m.matches_value(other)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,11 +558,11 @@ mod server;
 type Request = request::Request;
 type Response = response::Response;
 
-use percent_encoding::percent_decode;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use regex::Regex;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::convert::{From, Into};
 use std::fmt;
 use std::io;
@@ -753,18 +753,15 @@ impl Matcher {
                 let actual: serde_json::Value = serde_json::from_str(other).unwrap();
                 assert_json_include_no_panic(&actual, &expected).is_ok()
             }
-            Matcher::UrlEncoded(ref expected_field, ref expected_value) => other
-                .split('&')
-                .map(|pair| {
-                    let mut parts = pair.splitn(2, '=');
-                    let field =
-                        percent_decode(parts.next().unwrap().as_bytes()).decode_utf8_lossy();
-                    let value =
-                        percent_decode(parts.next().unwrap_or("").as_bytes()).decode_utf8_lossy();
-
-                    (field.to_string(), value.to_string())
+            Matcher::UrlEncoded(ref expected_field, ref expected_value) => serde_urlencoded::from_str::<HashMap<String, String>>(other)
+                .map(|params: HashMap<_, _>| {
+                    params
+                        .into_iter()
+                        .any(|(ref field, ref value)| {
+                            field == expected_field && value == expected_value
+                        })
                 })
-                .any(|(ref field, ref value)| field == expected_field && value == expected_value),
+                .unwrap_or(false),
             Matcher::Any => true,
             Matcher::AnyOf(ref matchers) => matchers.iter().any(|m| m.matches_value(other)),
             Matcher::AllOf(ref matchers) => matchers.iter().all(|m| m.matches_value(other)),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1289,7 +1289,7 @@ fn test_match_partial_query_by_urlencoded_all_of() {
         ]))
         .create();
 
-    let (status_line, _, _) = request("GET /hello?hello=world&something=else&num%20ber=o%20ne", "");
+    let (status_line, _, _) = request("GET /hello?hello=world&something=else&num+ber=o%20ne", "");
     assert_eq!("HTTP/1.1 200 OK\r\n", status_line);
 
     let (status_line, _, _) = request("GET /hello?hello=world&something=else", "");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1289,11 +1289,24 @@ fn test_match_partial_query_by_urlencoded_all_of() {
         ]))
         .create();
 
-    let (status_line, _, _) = request("GET /hello?hello=world&something=else&num+ber=o%20ne", "");
+    let (status_line, _, _) = request("GET /hello?hello=world&something=else&num%20ber=o%20ne", "");
     assert_eq!("HTTP/1.1 200 OK\r\n", status_line);
 
     let (status_line, _, _) = request("GET /hello?hello=world&something=else", "");
     assert_eq!("HTTP/1.1 501 Mock Not Found\r\n", status_line);
+}
+
+#[test]
+fn test_match_query_with_non_percent_url_escaping() {
+    let _m = mock("GET", "/hello")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("num ber".into(), "o ne".into()),
+            Matcher::UrlEncoded("hello".into(), "world".into()),
+        ]))
+        .create();
+
+    let (status_line, _, _) = request("GET /hello?hello=world&something=else&num+ber=o+ne", "");
+    assert_eq!("HTTP/1.1 200 OK\r\n", status_line);
 }
 
 #[test]


### PR DESCRIPTION
This is a fix that resolves #121 and also comes with a slightly leaner implementation of `Matcher::UrlEncoded`'s match arm in `Matcher::matches_value`

Open to any feedback / suggestions!