### PR TITLE
Add a matched() -> bool method to mock

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,38 @@
 //!
 //! ```
 //!
+//! You can also use the `matched` method to return a boolean for whether the mock was called the
+//! correct number of times without panicking
+//!
+//! ## Example
+//!
+//! ```
+//! use std::net::TcpStream;
+//! use std::io::{Read, Write};
+//! use mockito::{mock, server_address};
+//!
+//! let mock = mock("GET", "/").create();
+//!
+//! {
+//!     let mut stream = TcpStream::connect(server_address()).unwrap();
+//!     stream.write_all("GET / HTTP/1.1\r\n\r\n".as_bytes()).unwrap();
+//!     let mut response = String::new();
+//!     stream.read_to_string(&mut response).unwrap();
+//!     stream.flush().unwrap();
+//! }
+//!
+//! assert!(mock.matched());
+//!
+//! {
+//!     let mut stream = TcpStream::connect(server_address()).unwrap();
+//!     stream.write_all("GET / HTTP/1.1\r\n\r\n".as_bytes()).unwrap();
+//!     let mut response = String::new();
+//!     stream.read_to_string(&mut response).unwrap();
+//!     stream.flush().unwrap();
+//! }
+//! assert!(!mock.matched());
+//! ```
+//!
 //! # Matchers
 //!
 //! Mockito can match your request by method, path, query, headers or body.
@@ -1064,14 +1096,12 @@ impl Mock {
     /// Asserts that the expected amount of requests (defaults to 1 request) were performed.
     ///
     pub fn assert(&self) {
-        let mut opt_hits = None;
         let mut opt_message = None;
 
         {
             let state = server::STATE.lock().unwrap();
 
             if let Some(remote_mock) = state.mocks.iter().find(|mock| mock.id == self.id) {
-                opt_hits = Some(remote_mock.hits);
                 let mut message = match (self.expected_hits_at_least, self.expected_hits_at_most) {
                     (Some(min), Some(max)) if min == max => format!(
                         "\n> Expected {} request(s) to:\n{}\n...but received {}\n\n",
@@ -1109,18 +1139,29 @@ impl Mock {
             }
         }
 
-        match (opt_hits, opt_message) {
-            (Some(hits), Some(message)) => assert!(
-                match (self.expected_hits_at_least, self.expected_hits_at_most) {
-                    (Some(min), Some(max)) => hits >= min && hits <= max,
-                    (Some(min), None) => hits >= min,
-                    (None, Some(max)) => hits <= max,
-                    (None, None) => hits == 1,
-                },
-                "{}",
-                message
-            ),
+        match opt_message {
+            Some(message) => assert!(self.matched(), "{}", message),
             _ => panic!("Could not retrieve enough information about the remote mock."),
+        }
+    }
+
+    ///
+    /// Returns whether the expected amount of requests (defaults to 1) were performed.
+    ///
+    pub fn matched(&self) -> bool {
+        let state = server::STATE.lock().unwrap();
+
+        if let Some(remote_mock) = state.mocks.iter().find(|mock| mock.id == self.id) {
+            let hits = remote_mock.hits;
+
+            match (self.expected_hits_at_least, self.expected_hits_at_most) {
+                (Some(min), Some(max)) => hits >= min && hits <= max,
+                (Some(min), None) => hits >= min,
+                (None, Some(max)) => hits <= max,
+                (None, None) => hits == 1,
+            }
+        } else {
+            false
         }
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1422,3 +1422,15 @@ fn test_same_endpoint_different_responses_last_one_forever() {
     assert_eq!(response_500_2.0, "HTTP/1.1 500 Internal Server Error\r\n");
     assert_eq!(response_500_3.0, "HTTP/1.1 500 Internal Server Error\r\n");
 }
+
+#[test]
+fn test_matched_bool() {
+    let m = mock("GET", "/").create();
+
+    let (_, _, _) = request_with_body("GET /", "", "");
+    m.assert();
+    assert!(m.matched(), "matched method returns correctly");
+
+    let (_, _, _) = request_with_body("GET /", "", "");
+    assert!(!m.matched(), "matched method returns correctly");
+}


### PR DESCRIPTION
Hi!

Thanks so much for this library - I really appreciate the work you've put into it! I have a slightly unusual use case surrounding testing async processing and I'd basically like to check to see if the mock has matched while not panicking. It looks like `mockito::mock` isn't `UnwindSafe` so catching the `assert` panic requires wrapping it in a `AssertUnwindSafe` which I'm not totally sure is correct.

This just provides a `matched` method that returns a bool for this particular use case. Let me know what you think/if it's appropriate or not!


Thanks!!!