### PR TITLE
Fix clippy, option 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,7 +585,6 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-use serde_json;
 
 mod diff;
 mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -830,7 +830,7 @@ impl PathAndQueryMatcher {
 ///
 /// Stores information about a mocked request. Should be initialized via `mockito::mock()`.
 ///
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub struct Mock {
     id: String,
     method: String,

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,8 +6,6 @@ use std::mem;
 use std::net::TcpStream;
 use std::str;
 
-use httparse;
-
 #[derive(Debug)]
 pub struct Request {
     pub version: (u8, u8),
@@ -166,7 +164,7 @@ impl<'a> From<&'a TcpStream> for Request {
                 .map_err(|e| {
                     request.error = Some(e.to_string());
                 })
-                .and_then(|status| match status {
+                .map(|status| match status {
                     httparse::Status::Complete(head_length) => {
                         if let Some(a @ 0..=1) = req.version {
                             request.version = (1, a);
@@ -195,10 +193,8 @@ impl<'a> From<&'a TcpStream> for Request {
                         }
 
                         request.is_parsed = true;
-
-                        Ok(())
                     }
-                    httparse::Status::Partial => Ok(()),
+                    httparse::Status::Partial => (),
                 });
         }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct Response {
     pub status: Status,
     pub headers: Vec<(String, String)>,
@@ -21,16 +21,6 @@ impl fmt::Debug for Body {
         match *self {
             Body::Bytes(ref b) => b.fmt(f),
             Body::Fn(_) => f.write_str("<callback>"),
-        }
-    }
-}
-
-impl PartialEq for Body {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Body::Bytes(ref a), Body::Bytes(ref b)) => a == b,
-            (Body::Fn(ref a), Body::Fn(ref b)) => Arc::ptr_eq(a, b),
-            _ => false,
         }
     }
 }


### PR DESCRIPTION
Hi, as discussed in #128, I tried to fix the linting issues. This is one of two options, the simplest one. The main issue in in the implementation of the `PartialEq` trait for `response::Body`. This is due to the trickiness of comparing to closures.

The first proposed solution is to remove the unneeded `PartialEq`s from the `Mock`, `Response` and `Body` structs.