### PR TITLE
Fix clippy, option 2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,7 +585,6 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-use serde_json;
 
 mod diff;
 mod request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,8 +6,6 @@ use std::mem;
 use std::net::TcpStream;
 use std::str;
 
-use httparse;
-
 #[derive(Debug)]
 pub struct Request {
     pub version: (u8, u8),
@@ -166,7 +164,7 @@ impl<'a> From<&'a TcpStream> for Request {
                 .map_err(|e| {
                     request.error = Some(e.to_string());
                 })
-                .and_then(|status| match status {
+                .map(|status| match status {
                     httparse::Status::Complete(head_length) => {
                         if let Some(a @ 0..=1) = req.version {
                             request.version = (1, a);
@@ -195,10 +193,8 @@ impl<'a> From<&'a TcpStream> for Request {
                         }
 
                         request.is_parsed = true;
-
-                        Ok(())
                     }
-                    httparse::Status::Partial => Ok(()),
+                    httparse::Status::Partial => (),
                 });
         }
 


### PR DESCRIPTION
Hi, this is the second option to fix linting issues arisen in #128. This is **alternative** to #129.

A great shout out to @wolf4ood that concoted this solution. The details are in the last commit message, but the juice is the choice to compare only a part of the BodyFn bear by the `Body::Fn` variant.