### PR TITLE
Update assert-json-diff to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.17"
 difference = "2.0"
 colored = { version = "2.0.0", optional = true }
 log = "0.4.6"
-assert-json-diff = "1.0.3"
+assert-json-diff = "2.0.0"
 serde_urlencoded = "0.7.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -637,7 +637,7 @@ pub const SERVER_URL: &str = "http://127.0.0.1:1234";
 
 pub use crate::server::address as server_address;
 pub use crate::server::url as server_url;
-use assert_json_diff::assert_json_include_no_panic;
+use assert_json_diff::{assert_json_matches_no_panic, CompareMode};
 
 ///
 /// Initializes a mock for the provided `method` and `path`.
@@ -800,6 +800,7 @@ impl Matcher {
 
     #[allow(deprecated)]
     fn matches_value(&self, other: &str) -> bool {
+        let compare_json_config = assert_json_diff::Config::new(CompareMode::Inclusive);
         match self {
             Matcher::Exact(ref value) => value == other,
             Matcher::Binary(_) => false,
@@ -816,12 +817,12 @@ impl Matcher {
             Matcher::PartialJson(ref json_obj) => {
                 let actual: serde_json::Value = serde_json::from_str(other).unwrap();
                 let expected = json_obj.clone();
-                assert_json_include_no_panic(&actual, &expected).is_ok()
+                assert_json_matches_no_panic(&actual, &expected, compare_json_config).is_ok()
             }
             Matcher::PartialJsonString(ref value) => {
                 let expected: serde_json::Value = serde_json::from_str(value).unwrap();
                 let actual: serde_json::Value = serde_json::from_str(other).unwrap();
-                assert_json_include_no_panic(&actual, &expected).is_ok()
+                assert_json_matches_no_panic(&actual, &expected, compare_json_config).is_ok()
             }
             Matcher::UrlEncoded(ref expected_field, ref expected_value) => {
                 serde_urlencoded::from_str::<HashMap<String, String>>(other)


### PR DESCRIPTION
I recently released assert-json-diff 2.0.0 which had [a few breaking changes](https://github.com/davidpdrsn/assert-json-diff/blob/main/CHANGELOG.md#200---2021-01-23).