### PR TITLE
Handle httpparse error

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -166,6 +166,7 @@ impl<'a> From<&'a TcpStream> for Request {
                 .parse(&all_buf)
                 .map_err(|e| {
                     request.error = Some(e.to_string());
+                    request.is_parsed = true;
                 })
                 .map(|status| match status {
                     httparse::Status::Complete(head_length) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1492,3 +1492,12 @@ fn test_matched_bool() {
     let (_, _, _) = request_with_body("GET /", "", "");
     assert!(!m.matched(), "matched method returns correctly");
 }
+
+#[test]
+fn test_invalid_header_field_name() {
+    let _m = mock("GET", "/").create();
+
+    let (uppercase_status_line, _, body) = request("GET /", "Bad Header: something\r\n");
+    assert_eq!("HTTP/1.1 422 Mock Error\r\n", uppercase_status_line);
+    assert_eq!(body, httparse::Error::HeaderName.to_string())
+}


### PR DESCRIPTION
When httpparse fails to parse a request, it will return an error. For instance when a header is invalid, httparse will return error `Error::HeaderName`.
The current logic was to mark the error and re-enter the loop. When this happens, the buffer may be empty and the test will block indefinitely.

This change marks the request as `parsed` when httparse returns an error parsing the content so this can be returned back to the client.