### PR TITLE
Various fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1.25", features = ["full"] }
 [dev-dependencies]
 env_logger = "0.8"
 testing_logger = "0.1"
+reqwest = "0.11"
 
 [features]
 default = ["color"]

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,6 +20,7 @@ pub(crate) enum Command {
     GetLastUnmatchedRequest {
         response_sender: oneshot::Sender<Option<String>>,
     },
+    #[allow(dead_code)]
     Noop,
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,6 +20,7 @@ pub(crate) enum Command {
     GetLastUnmatchedRequest {
         response_sender: oneshot::Sender<Option<String>>,
     },
+    Noop,
 }
 
 impl Command {
@@ -115,6 +116,7 @@ impl Command {
 
                 let _send = response_sender.send(label);
             }
+            Command::Noop => {}
         }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -31,7 +31,7 @@ impl Command {
             response_sender,
         };
 
-        let _ = sender.send(cmd).await;
+        let _send = sender.send(cmd).await;
         response_receiver.await.unwrap_or(false)
     }
 
@@ -43,7 +43,7 @@ impl Command {
             response_sender,
         };
 
-        let _ = sender.send(cmd).await;
+        let _send = sender.send(cmd).await;
         response_receiver.await.unwrap()
     }
 
@@ -56,7 +56,7 @@ impl Command {
             response_sender,
         };
 
-        let _ = sender.blocking_send(cmd);
+        let _send = sender.blocking_send(cmd);
         response_receiver.blocking_recv().unwrap_or(false)
     }
 
@@ -65,7 +65,7 @@ impl Command {
 
         let cmd = Command::GetLastUnmatchedRequest { response_sender };
 
-        let _ = sender.send(cmd).await;
+        let _send = sender.send(cmd).await;
         response_receiver.await.unwrap_or(None)
     }
 
@@ -77,7 +77,7 @@ impl Command {
             } => {
                 state.mocks.push(remote_mock);
 
-                let _ = response_sender.send(true);
+                let _send = response_sender.send(true);
             }
             Command::GetMockHits {
                 mock_id,
@@ -89,7 +89,7 @@ impl Command {
                     .find(|remote_mock| remote_mock.inner.id == mock_id)
                     .map(|remote_mock| remote_mock.inner.hits);
 
-                let _ = response_sender.send(hits);
+                let _send = response_sender.send(hits);
             }
             Command::RemoveMock {
                 mock_id,
@@ -103,7 +103,7 @@ impl Command {
                     state.mocks.remove(pos);
                 }
 
-                let _ = response_sender.send(true);
+                let _send = response_sender.send(true);
             }
             Command::GetLastUnmatchedRequest { response_sender } => {
                 let last_unmatched_request = state.unmatched_requests.last_mut();
@@ -113,7 +113,7 @@ impl Command {
                     None => None,
                 };
 
-                let _ = response_sender.send(label);
+                let _send = response_sender.send(label);
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,8 @@ impl ErrorTrait for Error {}
 pub enum ErrorKind {
     /// The server is not running
     ServerFailure,
+    /// The server is busy
+    ServerBusy,
     /// Could not deliver a response
     ResponseFailure,
     /// The status code is invalid or out of range
@@ -64,6 +66,7 @@ impl ErrorKind {
     fn description(&self) -> &'static str {
         match self {
             ErrorKind::ServerFailure => "the server is not running",
+            ErrorKind::ServerBusy => "the server is busy",
             ErrorKind::ResponseFailure => "could not deliver a response",
             ErrorKind::InvalidStatusCode => "invalid status code",
             ErrorKind::RequestBodyFailure => "failed to read the request body",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,7 +669,6 @@ mod mock;
 mod request;
 mod response;
 mod server;
-mod server_pool;
 
 lazy_static! {
     pub(crate) static ref RUNTIME: Runtime = tokio::runtime::Builder::new_current_thread()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,7 @@ use lazy_static::lazy_static;
 pub use legacy::{mock, reset, server_address, server_url};
 pub use matcher::Matcher;
 pub use mock::Mock;
-pub use server::Server;
+pub use server::{Server, ServerGuard};
 use tokio::runtime::Runtime;
 
 mod command;

--- a/src/server.rs
+++ b/src/server.rs
@@ -189,8 +189,7 @@ impl Server {
 
         let mutex = state.clone();
         let server = async move {
-            loop {
-                let (stream, _) = listener.accept().await.unwrap();
+            while let Ok((stream, _)) = listener.accept().await {
                 let mutex = mutex.clone();
 
                 tokio::spawn(async move {

--- a/src/server.rs
+++ b/src/server.rs
@@ -280,7 +280,11 @@ impl Server {
     }
 
     pub(crate) fn busy(&self) -> bool {
-        self.busy
+        let state = self.state.clone();
+        let locked = state.try_lock().is_err();
+        let sender_busy = self.sender.try_send(Command::Noop).is_err();
+
+        self.busy || locked || sender_busy
     }
 
     pub(crate) fn set_busy(&mut self, busy: bool) {


### PR DESCRIPTION
Related to https://github.com/lipanski/mockito/issues/155 and https://github.com/lipanski/mockito/issues/157

- Use reqwest in tests
- Replace std:net::TcpListener with tokio::net::TcpListener
- Make sure oneshot senders don't get dropped before receiving
- Small refactoring in Mock::assert to avoid calling hits twice
- Stream with while not with loop
- Expose a ServerGuard object which dereferences to Server
-  When recycling servers, check if the sender & state are still busy
- Disable server pool for now
