### PR TITLE
Don't use outdated function in lib.rs example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,10 +241,10 @@
 //! ## Example
 //!
 //! ```
-//! use mockito::mock;
+//! let mut s = mockito::Server::new();
 //!
 //! // This will perform a full match against the query part
-//! let _m = mock("GET", "/test?hello=world").create();
+//! let _m = s.mock("GET", "/test?hello=world").create();
 //! ```
 //!
 //! # Matching by header


### PR DESCRIPTION
This example is still using `mockito::mock` instead of creating a `Server`, i guess this was an oversight when changing all the examples.