### PR TITLE
Replace tokio Mutexes with sync Mutexes

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -15,7 +15,7 @@ use std::ops::Drop;
 use std::path::Path;
 use std::string::ToString;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::sync::RwLock;
 
 #[derive(Clone, Debug)]
 pub struct InnerMock {
@@ -441,7 +441,7 @@ impl Mock {
     #[track_caller]
     pub fn assert(&self) {
         let mutex = self.state.clone();
-        let state = mutex.blocking_read();
+        let state = mutex.read().unwrap();
         if let Some(hits) = state.get_mock_hits(self.inner.id.clone()) {
             let matched = self.matched_hits(hits);
             let message = if !matched {
@@ -462,7 +462,7 @@ impl Mock {
     ///
     pub async fn assert_async(&self) {
         let mutex = self.state.clone();
-        let state = mutex.read().await;
+        let state = mutex.read().unwrap();
         if let Some(hits) = state.get_mock_hits(self.inner.id.clone()) {
             let matched = self.matched_hits(hits);
             let message = if !matched {
@@ -483,7 +483,7 @@ impl Mock {
     ///
     pub fn matched(&self) -> bool {
         let mutex = self.state.clone();
-        let state = mutex.blocking_read();
+        let state = mutex.read().unwrap();
         let Some(hits) = state.get_mock_hits(self.inner.id.clone()) else {
             return false;
         };
@@ -496,7 +496,7 @@ impl Mock {
     ///
     pub async fn matched_async(&self) -> bool {
         let mutex = self.state.clone();
-        let state = mutex.read().await;
+        let state = mutex.read().unwrap();
         let Some(hits) = state.get_mock_hits(self.inner.id.clone()) else {
             return false;
         };
@@ -518,7 +518,7 @@ impl Mock {
     pub fn create(mut self) -> Mock {
         let remote_mock = RemoteMock::new(self.inner.clone());
         let state = self.state.clone();
-        let mut state = state.blocking_write();
+        let mut state = state.write().unwrap();
         state.mocks.push(remote_mock);
 
         self.created = true;
@@ -532,7 +532,7 @@ impl Mock {
     pub async fn create_async(mut self) -> Mock {
         let remote_mock = RemoteMock::new(self.inner.clone());
         let state = self.state.clone();
-        let mut state = state.write().await;
+        let mut state = state.write().unwrap();
         state.mocks.push(remote_mock);
 
         self.created = true;
@@ -545,7 +545,7 @@ impl Mock {
     ///
     pub fn remove(&self) {
         let mutex = self.state.clone();
-        let mut state = mutex.blocking_write();
+        let mut state = mutex.write().unwrap();
         state.remove_mock(self.inner.id.clone());
     }
 
@@ -554,7 +554,7 @@ impl Mock {
     ///
     pub async fn remove_async(&self) {
         let mutex = self.state.clone();
-        let mut state = mutex.write().await;
+        let mut state = mutex.write().unwrap();
         state.remove_mock(self.inner.id.clone());
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -358,11 +358,9 @@ async fn handle_request(
 
     let mutex = state.clone();
     let mut state = mutex.write().unwrap();
-
-    let mut mocks_stream = state.mocks.iter_mut();
     let mut matching_mocks: Vec<&mut RemoteMock> = vec![];
 
-    while let Some(mock) = mocks_stream.next() {
+    for mock in state.mocks.iter_mut() {
         if mock.matches(&mut request) {
             matching_mocks.push(mock);
         }

--- a/src/server_pool.rs
+++ b/src/server_pool.rs
@@ -78,11 +78,16 @@ impl ServerPool {
             .await
             .map_err(|err| Error::new_with_context(ErrorKind::Deadlock, err))?;
 
+        let server = if self.created < self.max_size {
+            Some(Server::try_new_with_port_async(0).await?)
+        } else {
+            None
+        };
+
         let state_mutex = self.state.clone();
         let mut state = state_mutex.lock().unwrap();
 
-        if self.created < self.max_size {
-            let server = Server::try_new_with_port_async(0).await?;
+        if let Some(server) = server {
             state.push_back(server);
         }
 

--- a/src/server_pool.rs
+++ b/src/server_pool.rs
@@ -93,8 +93,8 @@ impl ServerPool {
         }
     }
 
-    fn recycle(&'static self, mut server: Server) {
-        server.reset_async();
+    fn recycle(&self, mut server: Server) {
+        server.reset();
         let state_mutex = self.state.clone();
         let mut state = state_mutex.lock().unwrap();
         state.push_back(server);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1993,3 +1993,16 @@ async fn test_match_body_asnyc() {
 
     assert_eq!(200, response.status());
 }
+
+#[tokio::test]
+async fn test_join_all_async() {
+    let futures = (0..10).map(|_| async {
+        let mut s = Server::new_async().await;
+        let m = s.mock("POST", "/").create_async().await;
+
+        reqwest::Client::new().post(s.url()).send().await.unwrap();
+        m.assert_async().await;
+    });
+
+    let _results = futures::future::join_all(futures).await;
+}


### PR DESCRIPTION
Closes https://github.com/lipanski/mockito/issues/166

This MR replaces the tokio Mutexes/RwLocks with the sync Mutex/RwLock which is [preferred](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html) as long as the sync Mutex is not held across `await` calls.

Since the server state is now wrapped in a sync Mutex, there's no need to call `block_on` inside the `Drop` implementations any more.

It also replaces the tokio oneshot channel that shares the server port with a sync mpsc channel. This was the cause for the server pool blocking on `futures::future::join_all`.