### PR TITLE
Use HeaderMap for headers in mock and response

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,8 @@
 use crate::{Error, ErrorKind};
 use hyper::body;
 use hyper::body::Buf;
+use hyper::header::AsHeaderName;
+use hyper::header::HeaderValue;
 use hyper::Body as HyperBody;
 use hyper::Request as HyperRequest;
 
@@ -41,17 +43,12 @@ impl Request {
     }
 
     /// Retrieves all the header values for the given header field name
-    pub fn header(&self, header_name: &str) -> Vec<&str> {
-        self.inner
-            .headers()
-            .get_all(header_name)
-            .iter()
-            .map(|item| item.to_str().unwrap())
-            .collect::<Vec<&str>>()
+    pub fn header<T: AsHeaderName>(&self, header_name: T) -> Vec<&HeaderValue> {
+        self.inner.headers().get_all(header_name).iter().collect()
     }
 
     /// Checks whether the provided header field exists
-    pub fn has_header(&self, header_name: &str) -> bool {
+    pub fn has_header<T: AsHeaderName>(&self, header_name: T) -> bool {
         self.inner.headers().contains_key(header_name)
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
 use crate::Request;
 use futures::stream::Stream;
+use hyper::HeaderMap;
 use hyper::StatusCode;
 use std::fmt;
 use std::io;
@@ -12,7 +13,7 @@ use tokio::sync::mpsc;
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Response {
     pub status: StatusCode,
-    pub headers: Vec<(String, String)>,
+    pub headers: HeaderMap<String>,
     pub body: Body,
 }
 
@@ -55,9 +56,11 @@ impl PartialEq for Body {
 
 impl Default for Response {
     fn default() -> Self {
+        let mut headers = HeaderMap::with_capacity(1);
+        headers.insert("connection", "close".parse().unwrap());
         Self {
             status: StatusCode::OK,
-            headers: vec![("connection".into(), "close".into())],
+            headers,
             body: Body::Bytes(Vec::new()),
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -44,7 +44,7 @@ impl RemoteMock {
         self.inner
             .headers
             .iter()
-            .all(|&(ref field, ref expected)| expected.matches_values(&request.header(field)))
+            .all(|(field, expected)| expected.matches_values(&request.header(field)))
     }
 
     fn body_matches(&self, request: &mut Request) -> bool {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate serde_json;
 
+use hyper::header::HeaderName;
 use mockito::{Matcher, Server};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -699,7 +700,7 @@ fn test_mock_preserves_header_order() {
 
     // Add a large number of headers so getting the same order accidentally is unlikely.
     for i in 0..100 {
-        let field = format!("x-custom-header-{}", i);
+        let field: HeaderName = format!("x-custom-header-{}", i).try_into().unwrap();
         let value = "test";
         mock = mock.with_header(&field, value);
         expected_headers.push(format!("{}: {}", field, value));


### PR DESCRIPTION
This uses the `http` types `HeaderMap`, `HeaderName` and `HeaderValue` where appropriate, instead of `Vec<(String, String)>`. This disallows invalid header names at the call site.

This is a breaking change, because the functions `Mock::match_header` and `Mock::with_header` no longer accept `&str`. They will accept `&'static str` however.