### PR TITLE
Re-export HeaderName

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,6 +670,7 @@
 //! ```
 //!
 pub use error::{Error, ErrorKind};
+pub use hyper::header::HeaderName;
 #[allow(deprecated)]
 pub use matcher::Matcher;
 pub use mock::Mock;


### PR DESCRIPTION
After #179 we need to re-export HeaderName so `&str` can be converted to `HeaderName` for `Mock::match_header` and `Mock::with_header`.

For example, the following won't compile because `header.as_str()` doesn't live for `'static`:
```rust
        let header: String = "content-type".to_string();
        let mut server = mockito::Server::new();

        server.mock("GET", "/greetings").match_header(
            header.as_str(),
            "application/json",
        );
```

The following won't compile because the compiler can't infer what type we're trying into:
```rust
        let header: String = "content-type".to_string();
        let mut server = mockito::Server::new();

        server.mock("GET", "/greetings").match_header(
            header.as_str().try_into().unwrap(),
            "application/json",
        );
```

We need to explicitly convert to a `HeaderName`, and we can't do that unless we have the type re-exported:
```rust
        let header: String = "content-type".to_string();
        let mut server = mockito::Server::new();

        server.mock("GET", "/greetings").match_header(
            mockito::HeaderName::try_from(header).unwrap(),
            "application/json",
        );
```