### PR TITLE
Introduce a local IntoHeaderName trait to avoid exposing hyper::header::HeaderName

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,8 @@ pub enum ErrorKind {
     ResponseBodyFailure,
     /// File not found
     FileNotFound,
+    /// Invalid header name
+    InvalidHeaderName,
 }
 
 impl ErrorKind {
@@ -75,6 +77,7 @@ impl ErrorKind {
             ErrorKind::RequestBodyFailure => "failed to read the request body",
             ErrorKind::ResponseBodyFailure => "failed to write the response body",
             ErrorKind::FileNotFound => "file not found",
+            ErrorKind::InvalidHeaderName => "invalid header name",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@
 pub use error::{Error, ErrorKind};
 #[allow(deprecated)]
 pub use matcher::Matcher;
-pub use mock::Mock;
+pub use mock::{IntoHeaderName, Mock};
 pub use request::Request;
 pub use server::Server;
 pub use server_pool::ServerGuard;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate serde_json;
 
-use hyper::header::HeaderName;
 use mockito::{Matcher, Server};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -700,7 +699,7 @@ fn test_mock_preserves_header_order() {
 
     // Add a large number of headers so getting the same order accidentally is unlikely.
     for i in 0..100 {
-        let field: HeaderName = format!("x-custom-header-{}", i).try_into().unwrap();
+        let field = format!("x-custom-header-{}", i);
         let value = "test";
         mock = mock.with_header(&field, value);
         expected_headers.push(format!("{}: {}", field, value));


### PR DESCRIPTION
Related to https://github.com/lipanski/mockito/pull/179 and the alternative to https://github.com/lipanski/mockito/pull/180