### PR TITLE
Use tokio runtime uniformly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ appveyor = { repository = "lipanski/mockito", branch = "master", service = "gith
 [dependencies]
 assert-json-diff = "2.0"
 colored = { version = "~2.0", optional = true }
-futures = "0.3"
+futures-core = "0.3"
 hyper = { version = "0.14", features = ["http1", "http2", "server", "stream"] }
 log = "0.4"
 rand = "0.8"
@@ -33,6 +33,7 @@ tokio = { version = "1.25", features = ["net", "rt", "sync"] }
 [dev-dependencies]
 env_logger = "0.8"
 testing_logger = "0.1"
+futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 reqwest = "0.11"
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::Request;
-use futures::stream::Stream;
+use futures_core::stream::Stream;
 use hyper::HeaderMap;
 use hyper::StatusCode;
 use std::fmt;

--- a/src/server.rs
+++ b/src/server.rs
@@ -207,7 +207,11 @@ impl Server {
     ///
     #[track_caller]
     pub(crate) fn try_new() -> Result<ServerGuard, Error> {
-        futures::executor::block_on(async { Server::try_new_async().await })
+        runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Cannot build local tokio runtime")
+            .block_on(async { Server::try_new_async().await })
     }
 
     ///


### PR DESCRIPTION
Uses the `tokio` runtime which is used in the other APIs.
